### PR TITLE
[codex] Expose spec-kit as a Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "grail-automation-codex",
+  "interface": {
+    "displayName": "Grail Automation Codex"
+  },
+  "plugins": [
+    {
+      "name": "spec-kit",
+      "source": {
+        "source": "local",
+        "path": "./spec-kit"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ Monorepo of Claude Code plugins, with optional Codex adapter metadata where need
 
 Codex plugin architecture is not interchangeable with Claude plugin architecture. Codex exposure is additive: use `.agents/plugins/marketplace.json` plus per-plugin `.codex-plugin/plugin.json` only for plugins that have been deliberately adapted for Codex.
 
+See `CODEX_MIGRATION.md` for the current Codex marketplace contents, candidate
+review, and migration rules.
+
 This is a **content-first repository** — almost entirely Markdown. There is no build system, test runner, CI pipeline, or linting config. The two MCP server plugins (`cloudflare`, `namecheap`) are the only ones with JavaScript code.
 
 ## Plugin Anatomy
@@ -39,6 +42,18 @@ Not every plugin uses all component types.
 - **Progressive discovery**: SKILL.md provides the summary; `references/*.md` provides depth. Link references with relative markdown links — Codex won't discover them otherwise
 - Keep SKILL.md focused; move detailed reference material to `references/`
 - `disable-model-invocation: true` keeps workflow skills user-invoked only; `user-invocable: false` marks background knowledge that users should not invoke directly
+- For Codex-only invocation policy or presentation metadata, use
+  `skills/<skill>/agents/openai.yaml`; do not assume Claude-specific
+  frontmatter is honored by Codex.
+
+### Codex Plugins
+
+- The repo-scoped Codex marketplace lives at `.agents/plugins/marketplace.json`.
+- Add entries only after the plugin has a reviewed `.codex-plugin/plugin.json`.
+- Keep marketplace `source.path` relative to the repository root and prefixed
+  with `./`.
+- Only `plugin.json` belongs in `.codex-plugin/`; keep skills, MCP config,
+  hooks, apps, scripts, and assets at the plugin root.
 
 ### Agents (agents/*.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ Monorepo of Claude Code plugins. Each plugin is a self-contained directory with 
 
 Some plugins may also include Codex adapter metadata such as `.codex-plugin/plugin.json`, but Claude and Codex plugin architectures are not interchangeable. Treat Codex exposure as a separate adapter layer.
 
+See `CODEX_MIGRATION.md` for the current Codex marketplace contents, candidate
+review, and migration rules.
+
 This is a **content-first repository** — almost entirely Markdown. There is no build system, test runner, CI pipeline, or linting config. The two MCP server plugins (`cloudflare`, `namecheap`) are the only ones with JavaScript code.
 
 ## Plugin Anatomy
@@ -39,6 +42,9 @@ Not every plugin uses all component types.
 - **Progressive discovery**: SKILL.md provides the summary; `references/*.md` provides depth. Link references with relative markdown links — Claude won't discover them otherwise
 - Keep SKILL.md focused; move detailed reference material to `references/`
 - `disable-model-invocation: true` keeps workflow skills user-invoked only; `user-invocable: false` marks background knowledge that users should not invoke directly
+- For Codex-only invocation policy or presentation metadata, use
+  `skills/<skill>/agents/openai.yaml`; do not assume Claude-specific
+  frontmatter is honored by Codex.
 
 ### Agents (agents/*.md)
 

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -1,0 +1,84 @@
+# Codex Migration Ledger
+
+This repository remains Claude-first, with Codex exposure added only when a
+plugin has been deliberately reviewed against Codex plugin structure.
+
+Current Codex docs baseline:
+- A Codex plugin needs `.codex-plugin/plugin.json`.
+- Plugin components such as `skills/`, `.mcp.json`, `.app.json`, `hooks/`, and
+  `assets/` stay at the plugin root; only `plugin.json` belongs under
+  `.codex-plugin/`.
+- Repo-scoped marketplaces live at `.agents/plugins/marketplace.json`.
+- Marketplace `source.path` is relative to the repository root and must begin
+  with `./`.
+- Codex skills require `name` and `description` frontmatter and can use
+  `skills/<skill>/agents/openai.yaml` for Codex-specific invocation policy and
+  presentation metadata.
+
+## Current Codex Marketplace
+
+The tracked Codex marketplace exposes:
+
+| Plugin | Status | Rationale |
+| --- | --- | --- |
+| `spec-kit` | Migrated | High-value workflow plugin; already structured as skills plus bundled scripts; no MCP or connector dependency. |
+
+The parked prototype files from the exploratory pass live under
+`.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
+and should be treated as reference material only.
+
+## Candidate Review
+
+### Direct Or Near-Direct Candidates
+
+These are skill-first plugins with little or no connector surface. They should
+be migrated next, one small PR at a time unless there is a reason to batch a
+homogeneous set.
+
+| Plugin | Recommendation | Notes |
+| --- | --- | --- |
+| `terminal-tidbits` | Next | Small, skill-only, low-risk Codex packaging candidate. |
+| `uv-package-manager` | Next | Skill-only reference/workflow plugin. |
+| `python-patterns` | Next | Skill-only reference plugin. |
+| `python-quickbooks` | Next | Skill-only library reference; verify examples remain generic. |
+| `openapi-spec-generation` | Next | Skill-only reference/workflow plugin. |
+| `oasb-scaffold` | Personal or repo-scoped | Useful to the user, but likely not broadly public outside OASBuilder work. |
+| `salesforce-soql` | Candidate | No bundled MCP, but depends on `sf` CLI and org-local schema hygiene. |
+| `workato-connector-sdk` | Candidate | Documentation-heavy and portable; verify no stale CLI claims before exposing. |
+| `workato-recipe` | Candidate with scripts | Useful, but scripts and generated view caches need a Codex smoke test. |
+| `workato-api` | Candidate with credentials | Requires clear environment-variable credential expectations. |
+
+### Already Exposed Or Covered Locally
+
+| Plugin | Status | Notes |
+| --- | --- | --- |
+| `workato-platform-cli` | Already exposed | A user-level Codex skill exists at `~/.codex/skills/workato-platform-cli/SKILL.md`. |
+| `playwright-cli` | Covered | A user-level Codex `playwright` skill already exists; migrate only if this repo plugin has distinct value. |
+| `cloudflare` | Partially covered | Codex has Cloudflare deployment/plugin support; this repo's MCP packaging needs a separate credential review. |
+
+### Requires Rewrite Or Connector Review
+
+These should not be mechanically exposed by adding manifests only.
+
+| Plugin group | Reason |
+| --- | --- |
+| `agents`, `staff-software-engineer` | Claude subagent definitions are not equivalent to Codex plugin skills. |
+| `issue-blaster`, `scraper-generator` | Include Claude subagents and workflow assumptions that need Codex-native rewrite. |
+| `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Many include placeholder connector or MCP expectations; review `.mcp.json` and decide Codex app/MCP mapping first. |
+| `google-workspace` | Large recipe surface; likely valuable, but needs connector/auth strategy before listing. |
+| `cloudflare`, `namecheap` | MCP server packaging and credential setup need Codex manifest and install-path review. |
+| `jq-for-clawd` | Claude session-history assumptions need a Codex session-log rewrite. |
+| `dev-browser` | Overlaps existing browser tooling and needs runtime/tooling validation. |
+| `espanso`, `karabiner-elements` | Likely personal machine-automation skills rather than public marketplace plugins. |
+
+## Migration Rules
+
+- Add a plugin to `.agents/plugins/marketplace.json` only after its
+  `.codex-plugin/plugin.json`, skill metadata, and runtime assumptions have been
+  reviewed.
+- Prefer `skills/<skill>/agents/openai.yaml` for Codex-only invocation policy
+  instead of overloading Claude-specific frontmatter.
+- Do not copy personal author emails into Codex manifests.
+- Keep Codex migration PRs separate from Claude cleanup PRs.
+- Validate both surfaces when a plugin remains dual-use: `claude plugin
+  validate <plugin>` for Claude and JSON/YAML/frontmatter checks for Codex.

--- a/spec-kit/.codex-plugin/plugin.json
+++ b/spec-kit/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "spec-kit",
+  "version": "0.1.0",
+  "description": "Streamlined spec-driven development for existing repositories: specs, clarification, plans, tasks, and safer implementation.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://github.com/spec-kit/spec-kit",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/spec-kit",
+  "license": "MIT",
+  "keywords": [
+    "spec",
+    "planning",
+    "sdd",
+    "tasks",
+    "specification",
+    "brownfield",
+    "implementation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Spec Kit",
+    "shortDescription": "Plan and implement features from lightweight executable specs",
+    "longDescription": "Use Spec Kit to capture feature intent, clarify only material ambiguity, generate brownfield-aware implementation plans, create dependency-ordered tasks, analyze artifact consistency, and execute work safely in existing repositories.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/spec-kit/spec-kit",
+    "defaultPrompt": [
+      "Use spec-kit to plan this feature",
+      "Review my current spec-kit plan",
+      "Turn this feature idea into tasks"
+    ],
+    "brandColor": "#2F6FED",
+    "screenshots": []
+  }
+}

--- a/spec-kit/skills/analyze/agents/openai.yaml
+++ b/spec-kit/skills/analyze/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/clarify/agents/openai.yaml
+++ b/spec-kit/skills/clarify/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/constitution/agents/openai.yaml
+++ b/spec-kit/skills/constitution/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/implement/agents/openai.yaml
+++ b/spec-kit/skills/implement/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/init/agents/openai.yaml
+++ b/spec-kit/skills/init/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/plan/agents/openai.yaml
+++ b/spec-kit/skills/plan/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/spec-kit-guide/agents/openai.yaml
+++ b/spec-kit/skills/spec-kit-guide/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Spec Kit Guide"
+  short_description: "Guide streamlined spec-driven development in existing repositories"
+  brand_color: "#2F6FED"
+  default_prompt: "Use spec-kit to turn this feature idea into a repo-aware plan and task list."

--- a/spec-kit/skills/specify/agents/openai.yaml
+++ b/spec-kit/skills/specify/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/spec-kit/skills/tasks/agents/openai.yaml
+++ b/spec-kit/skills/tasks/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- Add a repo-scoped Codex marketplace at `.agents/plugins/marketplace.json` with `spec-kit` as the first intentionally adapted plugin.
- Add `spec-kit/.codex-plugin/plugin.json` and Codex-specific `agents/openai.yaml` metadata for spec-kit skills.
- Add `CODEX_MIGRATION.md` to record the candidate review, current marketplace contents, and migration rules for follow-up plugins.
- Update `AGENTS.md` and `CLAUDE.md` so both agent surfaces point to the Codex migration ledger.

## Notes

- The exploratory prototype files were parked under ignored `.scratch/codex-adapter-prototype/2026-05-14/` before this branch was created.
- This PR does not bulk-list every Claude plugin. It exposes only `spec-kit`, because it is skill/script based and has no connector or MCP credential surface.
- Current OpenAI Codex docs were refreshed before editing: Codex plugins use `.codex-plugin/plugin.json`, repo marketplaces use `.agents/plugins/marketplace.json`, and Codex skill policy/presentation metadata can live at `skills/<skill>/agents/openai.yaml`.

## Validation

- `claude plugin validate .`
- `claude plugin validate <plugin>` for all 35 Claude plugin directories
- Codex marketplace and plugin manifest JSON parse plus path/policy checks
- Ruby YAML parse for all new `agents/openai.yaml` files
- Ruby frontmatter check for tracked skills/agents plus new Codex metadata
- `/bin/bash -n` for spec-kit scripts
- Focused spec-kit runtime smoke in `/tmp`
- `git diff --check`
- Hygiene scans across new Codex files for emails, hardcoded `/Users/...` paths, Salesforce org IDs, and API-key-looking strings
