### PR TITLE
[codex] Expose skill-only reference plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,6 +15,54 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "uv-package-manager",
+      "source": {
+        "source": "local",
+        "path": "./uv-package-manager"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    },
+    {
+      "name": "python-patterns",
+      "source": {
+        "source": "local",
+        "path": "./python-patterns"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    },
+    {
+      "name": "openapi-spec-generation",
+      "source": {
+        "source": "local",
+        "path": "./openapi-spec-generation"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    },
+    {
+      "name": "python-quickbooks",
+      "source": {
+        "source": "local",
+        "path": "./python-quickbooks"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Reference"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -22,6 +22,10 @@ The tracked Codex marketplace exposes:
 | Plugin | Status | Rationale |
 | --- | --- | --- |
 | `spec-kit` | Migrated | High-value workflow plugin; already structured as skills plus bundled scripts; no MCP or connector dependency. |
+| `uv-package-manager` | Migrated | Skill-only Python tooling workflow; no plugin-local state or connector dependency. |
+| `python-patterns` | Migrated | Skill-only Python reference and review workflow. |
+| `openapi-spec-generation` | Migrated | Skill-only OpenAPI workflow with local references. |
+| `python-quickbooks` | Migrated | Skill-only library reference; examples use placeholders rather than live credentials. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -37,11 +41,6 @@ homogeneous set.
 
 | Plugin | Recommendation | Notes |
 | --- | --- | --- |
-| `terminal-tidbits` | Next | Small, skill-only, low-risk Codex packaging candidate. |
-| `uv-package-manager` | Next | Skill-only reference/workflow plugin. |
-| `python-patterns` | Next | Skill-only reference plugin. |
-| `python-quickbooks` | Next | Skill-only library reference; verify examples remain generic. |
-| `openapi-spec-generation` | Next | Skill-only reference/workflow plugin. |
 | `oasb-scaffold` | Personal or repo-scoped | Useful to the user, but likely not broadly public outside OASBuilder work. |
 | `salesforce-soql` | Candidate | No bundled MCP, but depends on `sf` CLI and org-local schema hygiene. |
 | `workato-connector-sdk` | Candidate | Documentation-heavy and portable; verify no stale CLI claims before exposing. |
@@ -69,6 +68,7 @@ These should not be mechanically exposed by adding manifests only.
 | `cloudflare`, `namecheap` | MCP server packaging and credential setup need Codex manifest and install-path review. |
 | `jq-for-clawd` | Claude session-history assumptions need a Codex session-log rewrite. |
 | `dev-browser` | Overlaps existing browser tooling and needs runtime/tooling validation. |
+| `terminal-tidbits` | Stores user data in the plugin directory and assumes `${CLAUDE_PLUGIN_ROOT}`; needs a Codex-safe user-data path before listing. |
 | `espanso`, `karabiner-elements` | Likely personal machine-automation skills rather than public marketplace plugins. |
 
 ## Migration Rules

--- a/openapi-spec-generation/.codex-plugin/plugin.json
+++ b/openapi-spec-generation/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "openapi-spec-generation",
+  "version": "0.1.0",
+  "description": "OpenAPI 3.1 specification generation, validation, and SDK workflow guidance.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://spec.openapis.org/oas/latest.html",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/openapi-spec-generation",
+  "keywords": [
+    "openapi",
+    "api-design",
+    "specification",
+    "sdk-generation",
+    "validation",
+    "documentation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "OpenAPI Spec Generation",
+    "shortDescription": "Design, validate, and generate OpenAPI 3.1 specs",
+    "longDescription": "Use OpenAPI Spec Generation for design-first and code-first API specifications, validation and linting workflows, documentation patterns, and SDK generation guidance.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://spec.openapis.org/oas/latest.html",
+    "defaultPrompt": [
+      "Generate an OpenAPI spec for this API",
+      "Validate this OpenAPI contract",
+      "Plan SDK generation from this spec"
+    ],
+    "brandColor": "#6BA539",
+    "screenshots": []
+  }
+}

--- a/python-patterns/.codex-plugin/plugin.json
+++ b/python-patterns/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "python-patterns",
+  "version": "0.1.0",
+  "description": "Idiomatic Python patterns, best practices, and code review reference.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://docs.python.org/3/",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/python-patterns",
+  "keywords": [
+    "python",
+    "patterns",
+    "code-review",
+    "type-hints",
+    "refactoring",
+    "pep8"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Python Patterns",
+    "shortDescription": "Write and review idiomatic Python",
+    "longDescription": "Use Python Patterns when writing, reviewing, refactoring, or designing Python applications with emphasis on readability, correctness, type hints, idioms, testing, and maintainability.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.python.org/3/",
+    "defaultPrompt": [
+      "Review this Python code for idioms",
+      "Refactor this Python module cleanly",
+      "Design this Python package structure"
+    ],
+    "brandColor": "#3776AB",
+    "screenshots": []
+  }
+}

--- a/python-quickbooks/.codex-plugin/plugin.json
+++ b/python-quickbooks/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "python-quickbooks",
+  "version": "0.1.0",
+  "description": "Reference for the python-quickbooks library and QuickBooks Online API integration in Python.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://github.com/ej2/python-quickbooks",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/python-quickbooks",
+  "keywords": [
+    "quickbooks",
+    "qbo",
+    "python",
+    "accounting",
+    "api",
+    "integration"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "python-quickbooks",
+    "shortDescription": "Use QuickBooks Online from Python",
+    "longDescription": "Use python-quickbooks for QuickBooks Online API integration patterns in Python, including authentication, querying, creating and updating objects, payments, bills, invoices, batch operations, and common troubleshooting.",
+    "developerName": "Grail Automation",
+    "category": "Reference",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/ej2/python-quickbooks",
+    "defaultPrompt": [
+      "Create a QuickBooks invoice in Python",
+      "Query QuickBooks customers with python-quickbooks",
+      "Set up QuickBooks auth in Python"
+    ],
+    "brandColor": "#2CA01C",
+    "screenshots": []
+  }
+}

--- a/uv-package-manager/.codex-plugin/plugin.json
+++ b/uv-package-manager/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "uv-package-manager",
+  "version": "0.1.0",
+  "description": "uv package manager workflows for fast Python dependency management, project setup, locking, and CI integration.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://docs.astral.sh/uv/",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/uv-package-manager",
+  "keywords": [
+    "uv",
+    "python",
+    "package-manager",
+    "dependencies",
+    "virtualenv",
+    "lockfiles"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "uv Package Manager",
+    "shortDescription": "Set up and manage Python projects with uv",
+    "longDescription": "Use uv Package Manager for fast Python project setup, dependency management, virtual environments, lockfiles, Python version management, Docker and CI patterns, and migration from pip, pip-tools, or Poetry.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.astral.sh/uv/",
+    "defaultPrompt": [
+      "Set up this Python project with uv",
+      "Migrate this project from pip to uv",
+      "Review this repo's uv dependency workflow"
+    ],
+    "brandColor": "#5B5BD6",
+    "screenshots": []
+  }
+}


### PR DESCRIPTION
## Summary

- Add Codex plugin manifests for `uv-package-manager`, `python-patterns`, `openapi-spec-generation`, and `python-quickbooks`.
- Add those four skill-only/reference plugins to the repo-scoped Codex marketplace.
- Correct the migration ledger: `terminal-tidbits` is not safe to expose yet because it writes user data inside the plugin directory and assumes `${CLAUDE_PLUGIN_ROOT}`.

## Validation

- Codex marketplace and plugin manifest JSON parse plus path/policy checks
- Ruby frontmatter check for tracked skills/agents plus Codex metadata
- `git diff --check`
- Hygiene scan across new Codex files for emails, hardcoded `/Users/...` paths, Salesforce org IDs, and API-key-looking strings
- `claude plugin validate .`
- `claude plugin validate` for `uv-package-manager`, `python-patterns`, `openapi-spec-generation`, and `python-quickbooks`
