### PR TITLE
[codex] Make terminal-tidbits Codex-safe

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -63,6 +63,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Reference"
+    },
+    {
+      "name": "terminal-tidbits",
+      "source": {
+        "source": "local",
+        "path": "./terminal-tidbits"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -26,6 +26,7 @@ The tracked Codex marketplace exposes:
 | `python-patterns` | Migrated | Skill-only Python reference and review workflow. |
 | `openapi-spec-generation` | Migrated | Skill-only OpenAPI workflow with local references. |
 | `python-quickbooks` | Migrated | Skill-only library reference; examples use placeholders rather than live credentials. |
+| `terminal-tidbits` | Migrated | User-data path moved outside the plugin directory; defaults remain plugin-bundled. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -68,7 +69,6 @@ These should not be mechanically exposed by adding manifests only.
 | `cloudflare`, `namecheap` | MCP server packaging and credential setup need Codex manifest and install-path review. |
 | `jq-for-clawd` | Claude session-history assumptions need a Codex session-log rewrite. |
 | `dev-browser` | Overlaps existing browser tooling and needs runtime/tooling validation. |
-| `terminal-tidbits` | Stores user data in the plugin directory and assumes `${CLAUDE_PLUGIN_ROOT}`; needs a Codex-safe user-data path before listing. |
 | `espanso`, `karabiner-elements` | Likely personal machine-automation skills rather than public marketplace plugins. |
 
 ## Migration Rules

--- a/terminal-tidbits/.codex-plugin/plugin.json
+++ b/terminal-tidbits/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "terminal-tidbits",
+  "version": "0.1.0",
+  "description": "A personal reference system for terminal commands, shell syntax, and command-line concepts.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/terminal-tidbits",
+  "keywords": [
+    "terminal",
+    "shell",
+    "commands",
+    "reference",
+    "learning"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Terminal Tidbits",
+    "shortDescription": "Save and search notes about terminal commands",
+    "longDescription": "Use Terminal Tidbits to keep a small personal reference of terminal commands and shell concepts, seeded with defaults and stored in a user data file outside the plugin directory.",
+    "developerName": "Grail Automation",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Show my terminal tidbits",
+      "Add a terminal tidbit for xargs",
+      "Search my terminal tidbits for redirects"
+    ],
+    "brandColor": "#4B5563",
+    "screenshots": []
+  }
+}

--- a/terminal-tidbits/.gitignore
+++ b/terminal-tidbits/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 
-# User's terminal-tidbits file (not the defaults)
+# Legacy plugin-local working file from older installs.
 data/terminal-tidbits.json

--- a/terminal-tidbits/README.md
+++ b/terminal-tidbits/README.md
@@ -14,6 +14,10 @@ A personal reference system for terminal commands and concepts you're learning. 
 | `/terminal-tidbits:search` | Search tidbits |
 | `/terminal-tidbits:delete-all` | Clear all tidbits (or reset to defaults) |
 
+In Codex, invoke the same workflows as skills, for example
+`$terminal-tidbits:add`, `$terminal-tidbits:search`, or
+`$terminal-tidbits:show`.
+
 ## Usage Examples
 
 ### Show all tidbits
@@ -56,12 +60,15 @@ Or use natural language:
 
 ## Data Storage
 
-Tidbits are stored within the plugin directory:
+Default tidbits are shipped with the plugin, while user-added tidbits are stored
+outside the plugin directory so updates do not overwrite personal data:
 
 - **Default tidbits**: `data/default-terminal-tidbits.json` (ships with plugin)
-- **Your tidbits**: `data/terminal-tidbits.json` (created when you add/modify)
+- **Your tidbits**: `~/.terminal-tidbits/terminal-tidbits.json` by default
+- **Override path**: set `TERMINAL_TIDBITS_FILE` when you want a different file
 
-The working file (`terminal-tidbits.json`) is gitignored, so your custom tidbits won't be overwritten when the plugin updates.
+The working file lives outside the installed plugin/cache so custom tidbits
+survive plugin updates and work in both Claude Code and Codex.
 
 ## Pre-populated Tidbits
 

--- a/terminal-tidbits/skills/add/SKILL.md
+++ b/terminal-tidbits/skills/add/SKILL.md
@@ -22,7 +22,12 @@ Arguments may be provided as:
 
 ## Storage
 
-Tidbits are stored in `${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json` with this structure:
+Resolve paths before reading or writing:
+- `PLUGIN_ROOT`: `${CLAUDE_PLUGIN_ROOT}` in Claude Code. If unavailable, use the directory two levels above this `SKILL.md`.
+- `TIDBITS_FILE`: `${TERMINAL_TIDBITS_FILE}` if set; otherwise `~/.terminal-tidbits/terminal-tidbits.json`.
+- `DEFAULT_TIDBITS_FILE`: `${PLUGIN_ROOT}/data/default-terminal-tidbits.json`.
+
+Tidbits are stored in `TIDBITS_FILE` with this structure:
 ```json
 {
   "tidbits": [
@@ -43,12 +48,12 @@ Extract the `tid` and `bit` from $ARGUMENTS. If the user provided natural langua
 
 First, try to read the working tidbits file:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+TIDBITS_FILE
 ```
 
 If that file doesn't exist, read the defaults and use them as the starting point:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/default-terminal-tidbits.json
+DEFAULT_TIDBITS_FILE
 ```
 
 If neither file exists, start with an empty structure:
@@ -68,8 +73,9 @@ If duplicate found:
 
 Append the new tidbit to the array and write the updated JSON to the working file:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+TIDBITS_FILE
 ```
+Create the parent directory first if it does not exist.
 
 ### Step 5: Confirm
 

--- a/terminal-tidbits/skills/add/agents/openai.yaml
+++ b/terminal-tidbits/skills/add/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/terminal-tidbits/skills/delete-all/SKILL.md
+++ b/terminal-tidbits/skills/delete-all/SKILL.md
@@ -9,8 +9,10 @@ Delete tidbits from the user's collection with options for what to delete.
 
 ## Storage
 
-Working tidbits: `${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json`
-Default tidbits: `${CLAUDE_PLUGIN_ROOT}/data/default-terminal-tidbits.json`
+Resolve paths before reading or writing:
+- `PLUGIN_ROOT`: `${CLAUDE_PLUGIN_ROOT}` in Claude Code. If unavailable, use the directory two levels above this `SKILL.md`.
+- `TIDBITS_FILE`: `${TERMINAL_TIDBITS_FILE}` if set; otherwise `~/.terminal-tidbits/terminal-tidbits.json`.
+- `DEFAULT_TIDBITS_FILE`: `${PLUGIN_ROOT}/data/default-terminal-tidbits.json`.
 
 ## Instructions
 
@@ -20,12 +22,12 @@ Read both files to understand what exists:
 
 1. Read the defaults file:
    ```
-   ${CLAUDE_PLUGIN_ROOT}/data/default-terminal-tidbits.json
+   DEFAULT_TIDBITS_FILE
    ```
 
 2. Read the working file (if it exists):
    ```
-   ${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+   TIDBITS_FILE
    ```
 
 Determine:
@@ -85,6 +87,8 @@ Replace placeholders with actual counts:
 
 ### Step 4: Execute Based on Choice
 
+Before writing `TIDBITS_FILE`, create its parent directory if it does not exist.
+
 **If "My additions only":**
 - Filter the working file to keep only tidbits whose `tid` matches a default tidbit
 - Write the filtered list to the working file
@@ -102,7 +106,7 @@ Replace placeholders with actual counts:
 
 **If "Reset to original":**
 - Delete the working file entirely (so commands will read from defaults)
-- Use Bash to remove: `rm ${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json`
+- Use Bash to remove: `rm "$TIDBITS_FILE"`
 - Or write the defaults content to the working file
 
 ### Step 5: Confirm

--- a/terminal-tidbits/skills/delete-all/agents/openai.yaml
+++ b/terminal-tidbits/skills/delete-all/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/terminal-tidbits/skills/rm/SKILL.md
+++ b/terminal-tidbits/skills/rm/SKILL.md
@@ -15,7 +15,10 @@ The user provides the `tid` (identifier) of the tidbit to remove.
 
 ## Storage
 
-Tidbits are stored in `${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json`.
+Resolve paths before reading or writing:
+- `PLUGIN_ROOT`: `${CLAUDE_PLUGIN_ROOT}` in Claude Code. If unavailable, use the directory two levels above this `SKILL.md`.
+- `TIDBITS_FILE`: `${TERMINAL_TIDBITS_FILE}` if set; otherwise `~/.terminal-tidbits/terminal-tidbits.json`.
+- `DEFAULT_TIDBITS_FILE`: `${PLUGIN_ROOT}/data/default-terminal-tidbits.json`.
 
 ## Instructions
 
@@ -27,12 +30,12 @@ Extract the `tid` from $ARGUMENTS. The tid is the short identifier (e.g., `2>&1`
 
 First, try to read the working tidbits file:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+TIDBITS_FILE
 ```
 
 If that file doesn't exist, read the defaults:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/default-terminal-tidbits.json
+DEFAULT_TIDBITS_FILE
 ```
 
 If neither file exists, inform the user they have no tidbits yet.
@@ -63,8 +66,9 @@ Wait for user confirmation before proceeding.
 
 Remove the tidbit from the array and write the updated JSON to the working file:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+TIDBITS_FILE
 ```
+Create the parent directory first if it does not exist.
 
 ### Step 6: Confirm
 

--- a/terminal-tidbits/skills/rm/agents/openai.yaml
+++ b/terminal-tidbits/skills/rm/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/terminal-tidbits/skills/search/SKILL.md
+++ b/terminal-tidbits/skills/search/SKILL.md
@@ -15,7 +15,10 @@ The user optionally provides a search term. If no search term is provided, displ
 
 ## Storage
 
-Tidbits are stored in `${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json`.
+Resolve paths before reading:
+- `PLUGIN_ROOT`: `${CLAUDE_PLUGIN_ROOT}` in Claude Code. If unavailable, use the directory two levels above this `SKILL.md`.
+- `TIDBITS_FILE`: `${TERMINAL_TIDBITS_FILE}` if set; otherwise `~/.terminal-tidbits/terminal-tidbits.json`.
+- `DEFAULT_TIDBITS_FILE`: `${PLUGIN_ROOT}/data/default-terminal-tidbits.json`.
 
 ## Instructions
 
@@ -29,12 +32,12 @@ If $ARGUMENTS is empty or not provided, display all tidbits using the same forma
 
 First, try to read the working tidbits file:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+TIDBITS_FILE
 ```
 
 If that file doesn't exist, read the defaults:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/default-terminal-tidbits.json
+DEFAULT_TIDBITS_FILE
 ```
 
 If neither file exists, inform the user:

--- a/terminal-tidbits/skills/search/agents/openai.yaml
+++ b/terminal-tidbits/skills/search/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/terminal-tidbits/skills/show/SKILL.md
+++ b/terminal-tidbits/skills/show/SKILL.md
@@ -9,7 +9,10 @@ Display all tidbits in the user's terminal reference collection.
 
 ## Storage
 
-Tidbits are stored in `${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json`.
+Resolve paths before reading:
+- `PLUGIN_ROOT`: `${CLAUDE_PLUGIN_ROOT}` in Claude Code. If unavailable, use the directory two levels above this `SKILL.md`.
+- `TIDBITS_FILE`: `${TERMINAL_TIDBITS_FILE}` if set; otherwise `~/.terminal-tidbits/terminal-tidbits.json`.
+- `DEFAULT_TIDBITS_FILE`: `${PLUGIN_ROOT}/data/default-terminal-tidbits.json`.
 
 ## Instructions
 
@@ -17,12 +20,12 @@ Tidbits are stored in `${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json`.
 
 First, try to read the working tidbits file:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/terminal-tidbits.json
+TIDBITS_FILE
 ```
 
 If that file doesn't exist, read the defaults:
 ```
-${CLAUDE_PLUGIN_ROOT}/data/default-terminal-tidbits.json
+DEFAULT_TIDBITS_FILE
 ```
 
 If neither file exists, inform the user:

--- a/terminal-tidbits/skills/show/agents/openai.yaml
+++ b/terminal-tidbits/skills/show/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- Move Terminal Tidbits user data instructions out of the plugin directory and into `~/.terminal-tidbits/terminal-tidbits.json`, with `TERMINAL_TIDBITS_FILE` override support.
- Add Codex plugin metadata and user-invoked skill policy for the terminal-tidbits workflows.
- Add `terminal-tidbits` to the repo-scoped Codex marketplace and update the migration ledger.

## Validation

- Codex marketplace and terminal-tidbits manifest JSON parse plus listing check
- Ruby frontmatter check for terminal-tidbits skills
- Ruby YAML parse for terminal-tidbits `agents/openai.yaml` files
- `claude plugin validate terminal-tidbits`
- `git diff --check`
- Hygiene scan across new/changed terminal-tidbits Codex files for emails, hardcoded `/Users/...` paths, Salesforce org IDs, and API-key-looking strings
