### PR TITLE
[codex] Expose Salesforce and OASB plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -75,6 +75,30 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
+    },
+    {
+      "name": "salesforce-soql",
+      "source": {
+        "source": "local",
+        "path": "./salesforce-soql"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "oasb-scaffold",
+      "source": {
+        "source": "local",
+        "path": "./oasb-scaffold"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -27,6 +27,8 @@ The tracked Codex marketplace exposes:
 | `openapi-spec-generation` | Migrated | Skill-only OpenAPI workflow with local references. |
 | `python-quickbooks` | Migrated | Skill-only library reference; examples use placeholders rather than live credentials. |
 | `terminal-tidbits` | Migrated | User-data path moved outside the plugin directory; defaults remain plugin-bundled. |
+| `salesforce-soql` | Migrated | Salesforce CLI/reference workflow; no bundled MCP and org schemas remain local/ignored. |
+| `oasb-scaffold` | Migrated | Repo-specific OASBuilder convention skill; exposed for personal/repo-local usefulness. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -42,8 +44,6 @@ homogeneous set.
 
 | Plugin | Recommendation | Notes |
 | --- | --- | --- |
-| `oasb-scaffold` | Personal or repo-scoped | Useful to the user, but likely not broadly public outside OASBuilder work. |
-| `salesforce-soql` | Candidate | No bundled MCP, but depends on `sf` CLI and org-local schema hygiene. |
 | `workato-connector-sdk` | Candidate | Documentation-heavy and portable; verify no stale CLI claims before exposing. |
 | `workato-recipe` | Candidate with scripts | Useful, but scripts and generated view caches need a Codex smoke test. |
 | `workato-api` | Candidate with credentials | Requires clear environment-variable credential expectations. |

--- a/oasb-scaffold/.codex-plugin/plugin.json
+++ b/oasb-scaffold/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "oasb-scaffold",
+  "version": "0.1.0",
+  "description": "OASBuilder pipeline package conventions for scaffolding new stages.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/oasb-scaffold",
+  "keywords": [
+    "oasbuilder",
+    "openapi",
+    "pipeline",
+    "scaffolding",
+    "python"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "OASB Scaffold",
+    "shortDescription": "Follow OASBuilder package conventions",
+    "longDescription": "Use OASB Scaffold when creating or reviewing OASBuilder pipeline stages, package layout, CLI shape, schema conventions, validation patterns, and LLM-call boundaries.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Scaffold a new OASBuilder stage",
+      "Review this OASB package layout",
+      "Apply OASBuilder conventions here"
+    ],
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/salesforce-soql/.codex-plugin/plugin.json
+++ b/salesforce-soql/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "salesforce-soql",
+  "version": "0.1.0",
+  "description": "Salesforce data operations using the sf CLI: SOQL queries, schema exploration, and Bulk API 2.0 workflows.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://developer.salesforce.com/tools/salesforcecli",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/salesforce-soql",
+  "keywords": [
+    "salesforce",
+    "soql",
+    "sf-cli",
+    "schema",
+    "bulk-api",
+    "data"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Salesforce SOQL",
+    "shortDescription": "Query and inspect Salesforce data with sf CLI guidance",
+    "longDescription": "Use Salesforce SOQL to write and run SOQL queries, inspect object schemas, handle common SOQL and sf CLI gotchas, and prepare Bulk API 2.0 import, update, upsert, and delete workflows.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://developer.salesforce.com/tools/salesforcecli",
+    "defaultPrompt": [
+      "Write a SOQL query for this question",
+      "Explore this Salesforce object schema",
+      "Prepare a Salesforce bulk update"
+    ],
+    "brandColor": "#00A1E0",
+    "screenshots": []
+  }
+}

--- a/salesforce-soql/skills/describe/agents/openai.yaml
+++ b/salesforce-soql/skills/describe/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/salesforce-soql/skills/explore-schema/agents/openai.yaml
+++ b/salesforce-soql/skills/explore-schema/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/salesforce-soql/skills/query/agents/openai.yaml
+++ b/salesforce-soql/skills/query/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- Add Codex plugin manifests for `salesforce-soql` and `oasb-scaffold`.
- Add both plugins to the repo-scoped Codex marketplace.
- Add Codex user-invoked policy metadata for the Salesforce workflow skills.
- Update the Codex migration ledger to mark these as migrated.

## Validation

- Codex marketplace and plugin manifest JSON parse plus listing check
- Ruby YAML parse for Salesforce `agents/openai.yaml` files
- `claude plugin validate salesforce-soql`
- `claude plugin validate oasb-scaffold`
- `git diff --check`
- Hygiene scan across new Codex files for emails, hardcoded `/Users/...` paths, Salesforce org IDs, and API-key-looking strings
