### PR TITLE
Expose Workato API plugin to Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -99,6 +99,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "workato-api",
+      "source": {
+        "source": "local",
+        "path": "./workato-api"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -29,6 +29,7 @@ The tracked Codex marketplace exposes:
 | `terminal-tidbits` | Migrated | User-data path moved outside the plugin directory; defaults remain plugin-bundled. |
 | `salesforce-soql` | Migrated | Salesforce CLI/reference workflow; no bundled MCP and org schemas remain local/ignored. |
 | `oasb-scaffold` | Migrated | Repo-specific OASBuilder convention skill; exposed for personal/repo-local usefulness. |
+| `workato-api` | Migrated | REST reference and curl/httpx execution patterns; credentials come from environment variables or gitignored local notes. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -46,7 +47,6 @@ homogeneous set.
 | --- | --- | --- |
 | `workato-connector-sdk` | Candidate | Documentation-heavy and portable; verify no stale CLI claims before exposing. |
 | `workato-recipe` | Candidate with scripts | Useful, but scripts and generated view caches need a Codex smoke test. |
-| `workato-api` | Candidate with credentials | Requires clear environment-variable credential expectations. |
 
 ### Already Exposed Or Covered Locally
 

--- a/workato-api/.codex-plugin/plugin.json
+++ b/workato-api/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "workato-api",
+  "version": "0.1.0",
+  "description": "Workato Developer API reference and curl/httpx execution guidance for workspace resources.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://docs.workato.com/workato-api/",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/workato-api",
+  "keywords": [
+    "workato",
+    "developer-api",
+    "rest-api",
+    "recipes",
+    "connections",
+    "jobs",
+    "automation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workato API",
+    "shortDescription": "Inspect and manage Workato resources through the Developer API",
+    "longDescription": "Use Workato API for endpoint lookup, request construction, pagination handling, response parsing, and cautious curl/httpx execution against Workato Developer API resources such as recipes, jobs, connections, folders, projects, lookup tables, properties, and API clients.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.workato.com/workato-api/",
+    "defaultPrompt": [
+      "Look up this Workato API endpoint",
+      "Build a safe Workato API curl command",
+      "Inspect this Workato API response shape"
+    ],
+    "brandColor": "#F45A2A",
+    "screenshots": []
+  }
+}

--- a/workato-api/README.md
+++ b/workato-api/README.md
@@ -4,7 +4,7 @@ Workato Developer API reference and execution framework for managing workspace r
 
 ## What This Plugin Does
 
-Provides Claude Code with complete reference documentation for all 120+ Workato Developer API endpoints across 21 resource categories. When activated, Claude can:
+Provides Claude Code or Codex with reference documentation for Workato Developer API endpoints across 21 resource categories. When activated, an agent can:
 
 - Query and manage Workato recipes, connections, jobs, lookup tables, folders, and projects
 - Execute API calls via curl with proper authentication and response parsing
@@ -18,7 +18,7 @@ Provides Claude Code with complete reference documentation for all 120+ Workato 
 Create a Developer API Client in your Workato workspace:
 **Workspace Admin > API Clients > Create client**
 
-Set the token as an environment variable:
+Set the token as an environment variable. Do not commit tokens or workspace-specific values to this repository.
 
 ```bash
 export WORKATO_API_TOKEN="your-token-here"
@@ -42,6 +42,8 @@ Or use environment variables:
 export WORKATO_WORKSPACE_ID="your-workspace-id"
 export WORKATO_BASE_URL="https://www.workato.com"  # US default
 ```
+
+Environment variables are preferred for values that vary by shell, project, or automation job. Use `.local.md` only for local notes that should remain gitignored.
 
 ### 3. Script Usage
 

--- a/workato-api/skills/workato-api/SKILL.md
+++ b/workato-api/skills/workato-api/SKILL.md
@@ -25,7 +25,7 @@ This skill enables you to query and manage a Workato workspace via the Developer
 
 ## Workspace Configuration
 
-If a `.local.md` file exists in this skill directory, read it for workspace-specific configuration (workspace ID, data center, jq path). Also check environment variables:
+Prefer environment variables for runtime configuration. If a `.local.md` file exists in this skill directory, read it only for workspace-specific local notes (workspace ID, data center, jq path). Never write tokens or workspace-specific values to tracked files.
 
 - `WORKATO_API_TOKEN` — Bearer token (required). From Workato API Client (Workspace Admin > API Clients).
 - `WORKATO_WORKSPACE_ID` — Workspace ID override.
@@ -140,6 +140,8 @@ curl -s -H "Authorization: Bearer $WORKATO_API_TOKEN" \
 ```
 
 ## Safety Rules
+
+For Codex, treat this skill as explicit-invocation only. Do not proactively call authenticated Workato endpoints unless the user has clearly asked for Workato API execution in the current task.
 
 **Before executing any write operation** (POST, PUT, DELETE that creates, updates, or deletes data):
 1. Confirm with the user what will be changed

--- a/workato-api/skills/workato-api/agents/openai.yaml
+++ b/workato-api/skills/workato-api/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary
- add Codex plugin metadata for workato-api
- list workato-api in the Codex marketplace
- document env-first credential handling and explicit-invocation safety

## Validation
- jq empty .agents/plugins/marketplace.json workato-api/.codex-plugin/plugin.json
- ruby YAML parse for workato-api openai.yaml
- ruby SKILL.md frontmatter check
- claude plugin validate workato-api
- claude plugin validate .
- git diff --check
- hygiene scans for emails, local paths, org IDs, and token-like values in touched files