### PR TITLE
Expose Workato recipe analyzer to Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -111,6 +111,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Integrations"
+    },
+    {
+      "name": "workato-recipe",
+      "source": {
+        "source": "local",
+        "path": "./workato-recipe"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -30,6 +30,7 @@ The tracked Codex marketplace exposes:
 | `salesforce-soql` | Migrated | Salesforce CLI/reference workflow; no bundled MCP and org schemas remain local/ignored. |
 | `oasb-scaffold` | Migrated | Repo-specific OASBuilder convention skill; exposed for personal/repo-local usefulness. |
 | `workato-api` | Migrated | REST reference and curl/httpx execution patterns; credentials come from environment variables or gitignored local notes. |
+| `workato-recipe` | Migrated | Script-backed recipe analysis now uses the stable root CLI and avoids Claude-only path/subagent assumptions for Codex. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -46,7 +47,6 @@ homogeneous set.
 | Plugin | Recommendation | Notes |
 | --- | --- | --- |
 | `workato-connector-sdk` | Candidate | Documentation-heavy and portable; verify no stale CLI claims before exposing. |
-| `workato-recipe` | Candidate with scripts | Useful, but scripts and generated view caches need a Codex smoke test. |
 
 ### Already Exposed Or Covered Locally
 

--- a/workato-recipe/.codex-plugin/plugin.json
+++ b/workato-recipe/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "workato-recipe",
+  "version": "1.1.0",
+  "description": "Parse and analyze Workato recipe JSON exports by extracting focused logic views.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://docs.workato.com/recipes/",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/workato-recipe",
+  "keywords": [
+    "workato",
+    "recipes",
+    "json",
+    "integration",
+    "analysis",
+    "data-flow"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workato Recipe Analyzer",
+    "shortDescription": "Extract compact views from Workato recipe exports",
+    "longDescription": "Use Workato Recipe Analyzer to preprocess large Workato recipe JSON exports into focused summary and unified-logic files, then answer questions about control flow, data mappings, error handling, callable recipe parameters, and integration behavior.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.workato.com/recipes/",
+    "defaultPrompt": [
+      "Analyze this Workato recipe export",
+      "Summarize this recipe's control flow",
+      "Trace this field mapping through the recipe"
+    ],
+    "brandColor": "#F45A2A",
+    "screenshots": []
+  }
+}

--- a/workato-recipe/README.md
+++ b/workato-recipe/README.md
@@ -1,6 +1,6 @@
 # workato-recipe
 
-Generic Workato recipe extraction and fidelity utilities for Claude Code.
+Generic Workato recipe extraction and fidelity utilities for Claude Code and Codex.
 
 ## Stable CLI Contract
 

--- a/workato-recipe/pyproject.toml
+++ b/workato-recipe/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workato-recipe-plugin"
 version = "1.1.0"
-description = "Generic Workato recipe extraction and fidelity utilities for Claude Code"
+description = "Generic Workato recipe extraction and fidelity utilities for Claude Code and Codex"
 requires-python = ">=3.13"
 dependencies = [
     "jsonschema>=4.25.1",

--- a/workato-recipe/skills/workato-recipe/SKILL.md
+++ b/workato-recipe/skills/workato-recipe/SKILL.md
@@ -24,8 +24,15 @@ Determine the `.recipe.json` path from:
 
 ### 2. Run preprocessing
 
+Resolve `PLUGIN_ROOT` to the root of this plugin before running commands:
+- In Claude Code, use `CLAUDE_PLUGIN_ROOT` when it is available.
+- In Codex, infer it from this skill path: `workato-recipe/skills/workato-recipe/SKILL.md` lives two directories below the plugin root.
+- If neither is obvious, locate the directory containing `workato-recipe/cli.py`.
+
+Call the stable plugin CLI rather than internal scripts:
+
 ```bash
-uv run python "${CLAUDE_SKILL_DIR}/scripts/extract_views.py" "$RECIPE_PATH"
+uv run --project "$PLUGIN_ROOT" python "$PLUGIN_ROOT/cli.py" extract --recipe "$RECIPE_PATH"
 ```
 
 The script outputs the views directory path to stdout. Views are cached in
@@ -46,8 +53,9 @@ Based on the argument or question:
 - For callable recipes, show parameters and results
 
 **deep** (argument contains "deep", a specific question, or a block reference):
-- Spawn the `workato-recipe:recipe-analyzer` subagent with the views directory path and question
-- The subagent reads `summary.json` and `unified_logic.md` to provide detailed analysis
+- Read `summary.json` and `unified_logic.md` from the views directory.
+- Answer the question by tracing block numbers, data pills, branches, and variable mutations.
+- In Claude Code, you may delegate to the `workato-recipe:recipe-analyzer` subagent if it is available. In Codex, analyze inline; Claude subagent definitions are not a Codex plugin interface.
 
 ## View Files
 
@@ -58,5 +66,5 @@ Based on the argument or question:
 
 ## References
 
-- `${CLAUDE_SKILL_DIR}/references/recipe-schema.md` — Recipe JSON structure and datapill syntax
-- `${CLAUDE_SKILL_DIR}/references/view-formats.md` — View file formats and cross-referencing
+- `references/recipe-schema.md` — Recipe JSON structure and datapill syntax
+- `references/view-formats.md` — View file formats and cross-referencing


### PR DESCRIPTION
## Summary
- add Codex plugin metadata for workato-recipe
- list workato-recipe in the Codex marketplace
- replace Claude-only skill path/subagent assumptions with the stable root CLI and inline Codex analysis guidance

## Validation
- jq empty .agents/plugins/marketplace.json workato-recipe/.codex-plugin/plugin.json
- ruby SKILL.md frontmatter check
- claude plugin validate workato-recipe
- claude plugin validate .
- git diff --check
- uv run --project workato-recipe python workato-recipe/cli.py self-test
- hygiene scans for emails, local paths, org IDs, and token-like values in touched files