### PR TITLE
Expose Workato connector SDK plugin to Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -123,6 +123,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Integrations"
+    },
+    {
+      "name": "workato-connector-sdk",
+      "source": {
+        "source": "local",
+        "path": "./workato-connector-sdk"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -31,6 +31,7 @@ The tracked Codex marketplace exposes:
 | `oasb-scaffold` | Migrated | Repo-specific OASBuilder convention skill; exposed for personal/repo-local usefulness. |
 | `workato-api` | Migrated | REST reference and curl/httpx execution patterns; credentials come from environment variables or gitignored local notes. |
 | `workato-recipe` | Migrated | Script-backed recipe analysis now uses the stable root CLI and avoids Claude-only path/subagent assumptions for Codex. |
+| `workato-connector-sdk` | Migrated | Documentation-heavy connector SDK plugin; stale CLI claims and copied token/project examples were corrected before exposure. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -40,13 +41,9 @@ and should be treated as reference material only.
 
 ### Direct Or Near-Direct Candidates
 
-These are skill-first plugins with little or no connector surface. They should
-be migrated next, one small PR at a time unless there is a reason to batch a
-homogeneous set.
-
-| Plugin | Recommendation | Notes |
-| --- | --- | --- |
-| `workato-connector-sdk` | Candidate | Documentation-heavy and portable; verify no stale CLI claims before exposing. |
+This bucket is currently empty. The near-direct Workato candidates have been
+migrated; remaining plugin groups need rewrite, connector, MCP, or personal
+scope decisions rather than mechanical manifest work.
 
 ### Already Exposed Or Covered Locally
 

--- a/workato-connector-sdk/.codex-plugin/plugin.json
+++ b/workato-connector-sdk/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "workato-connector-sdk",
+  "version": "0.1.0",
+  "description": "Workato Connector SDK guidance for building, testing, and improving custom connectors.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://docs.workato.com/developing-connectors/sdk/",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/workato-connector-sdk",
+  "keywords": [
+    "workato",
+    "connector-sdk",
+    "custom-connectors",
+    "ruby",
+    "rspec",
+    "integration"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workato Connector SDK",
+    "shortDescription": "Build and test Workato custom connectors",
+    "longDescription": "Use Workato Connector SDK for custom connector architecture, authentication, actions, triggers, schemas, data formats, recipe-builder UX patterns, local Ruby gem CLI workflows, RSpec testing, and production-quality connector review.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.workato.com/developing-connectors/sdk/",
+    "defaultPrompt": [
+      "Help me design a Workato custom connector",
+      "Review this Workato connector action",
+      "Debug this Workato SDK CLI command"
+    ],
+    "brandColor": "#F45A2A",
+    "screenshots": []
+  }
+}

--- a/workato-connector-sdk/README.md
+++ b/workato-connector-sdk/README.md
@@ -1,6 +1,6 @@
 # Workato Connector SDK Plugin
 
-Comprehensive Workato Connector SDK documentation and best practices for Claude Code.
+Comprehensive Workato Connector SDK documentation and best practices for Claude Code and Codex.
 
 ## Overview
 
@@ -40,7 +40,7 @@ This plugin provides expertise for building Workato custom connectors, covering:
 
 ## Installation
 
-This plugin is part of the local-plugins marketplace. Enable it in Claude Code settings.
+This plugin is part of the local plugin marketplace. Enable it in Claude Code or install it from the Codex marketplace.
 
 ## Contents
 

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/SKILL.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/SKILL.md
@@ -24,7 +24,7 @@ The Workato SDK CLI (`workato-connector-sdk` gem) enables local connector develo
 - Local execution and testing of connector code
 - RSpec integration for automated testing
 - VCR cassette recording for API mocking
-- Push/pull commands for Workato platform sync
+- Push commands for Workato platform sync
 
 ## Installation
 
@@ -32,7 +32,16 @@ The Workato SDK CLI (`workato-connector-sdk` gem) enables local connector develo
 gem install workato-connector-sdk
 ```
 
-Requirements: Ruby 2.7+, Bundler
+Workato's current SDK CLI getting-started docs list Ruby 2.7.x, 3.0.x, and 3.1.x as supported. Local installs may run on newer Ruby versions, but verify with the installed gem before assuming compatibility.
+
+The Connector SDK gem and the Workato Platform CLI can both expose a `workato` command. Before running SDK CLI commands, check:
+
+```bash
+type -a workato
+workato version
+```
+
+The Connector SDK gem uses `workato version`, not `workato --version`. If `workato --version` succeeds but `workato version` fails, you are probably invoking the Platform CLI, not the Ruby Connector SDK CLI.
 
 ## Project Structure
 
@@ -82,14 +91,10 @@ workato exec connection.authorization --settings=settings.yaml
 ### Push to Workato
 
 ```bash
-workato push --title="My Connector" --api-token=YOUR_TOKEN
+WORKATO_API_TOKEN="<API_TOKEN>" workato push --title="My Connector"
 ```
 
-### Pull from Workato
-
-```bash
-workato pull --connector-id=12345 --api-token=YOUR_TOKEN
-```
+`workato push` reads `WORKATO_API_TOKEN` and `WORKATO_BASE_URL` from the environment unless `--api-token` or `--environment` is provided explicitly. The Connector SDK gem does not provide a `workato pull` command; use Workato's UI or API workflows when you need to retrieve existing connector source.
 
 ## RSpec Testing
 
@@ -174,12 +179,11 @@ end
 ### Encrypted Settings
 
 ```bash
-# Generate master key and encrypt settings
-workato generate_key
-workato encrypt settings.yaml
+# Create or edit encrypted settings
+workato edit settings.yaml.enc
 ```
 
-Creates `settings.yaml.enc` (safe to commit) and `master.key` (gitignore).
+Keep plaintext `settings.yaml`, `master.key`, and any files containing credentials gitignored. `WORKATO_CONNECTOR_MASTER_KEY` takes precedence over a key file when decrypting settings.
 
 ### Settings File Format
 
@@ -192,10 +196,7 @@ environment: sandbox
 
 ### Environment Variables
 
-```bash
-export WORKATO_API_KEY=your-key
-workato exec actions.test --settings-from-env
-```
+Use environment variables for SDK CLI authentication to Workato itself, such as `WORKATO_API_TOKEN`, `WORKATO_BASE_URL`, and `WORKATO_CONNECTOR_MASTER_KEY`. Connector runtime credentials should still be passed through a plain or encrypted settings file with `--settings`.
 
 ## Debugging
 

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__actions.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__actions.md
@@ -28,7 +28,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__methods.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__methods.md
@@ -28,7 +28,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__multistep-actions.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__multistep-actions.md
@@ -58,8 +58,8 @@ In this case, the contents of the file `bigquery_input.json` contains
 ```ruby
  
     {
-        "project_id": "named-reporter-237205",
-        "query": "SELECT * FROM `named-reporter-237205.Lead_data.2mill_table` t1",
+        "project_id": "example-project",
+        "query": "SELECT * FROM `example-project.sample_dataset.sample_table` t1",
         "wait_for_query": "true"
     }
 
@@ -82,15 +82,15 @@ To run a multistep action, you give the same command as you would a standard act
     }
     INPUT
     {
-      "project_id": "named-reporter-237205",
-      "query": "SELECT * FROM `named-reporter-237205.Lead_data.2mill_table` t1",
+      "project_id": "example-project",
+      "query": "SELECT * FROM `example-project.sample_dataset.sample_table` t1",
       "wait_for_query": "true"
     }
 
-    RestClient.post "https://bigquery.googleapis.com/bigquery/v2/projects/named-reporter-237205/queries", "{\"query\":\"SELECT * FROM `named-reporter-237205.Lead_data.2mill_table` t1 left join `named-reporter-237205.Lead_data.2mill_table` t2 on t1.start_time = t2.start_time\",\"timeoutMs\":\"25000\",\"useLegacySql\":false}", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"Bearer ya29.c.Kp8BFQgUT1EOcK5YBwTEv60KokPYvLLWJRFsbfd9S0oGEB3cW5cp1pXTJRZreYPB4B06Z1_YdvhLQByhe9fP_FjziQc6rCtEfGs9zZdMZpXKUFHWEqzG44qxni-jibwaLEgWLw3zaqv42y00x28jUmZQdP3AQilOPdn1xRwf6s-gWi_95d1t0qDe478VnclTIrZ_SmCMtDTTbdU1yvkA80TQ...", "Content-Length"=>"207", "Content-Type"=>"application/json", "User-Agent"=>"rest-client/2.0.2 (darwin19.6.0 x86_64) ruby/2.4.10p364"
+    RestClient.post "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/queries", "{\"query\":\"SELECT * FROM `example-project.sample_dataset.sample_table` t1 left join `example-project.sample_dataset.sample_table` t2 on t1.start_time = t2.start_time\",\"timeoutMs\":\"25000\",\"useLegacySql\":false}", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"Bearer <ACCESS_TOKEN>", "Content-Length"=>"207", "Content-Type"=>"application/json", "User-Agent"=>"rest-client/2.0.2 (darwin19.6.0 x86_64) ruby/2.4.10p364"
     # => 200 OK | application/json 176 bytes       
 
-    RestClient.get "https://bigquery.googleapis.com/bigquery/v2/projects/named-reporter-237205/jobs/job_LnXWC2bcE64hzeBlYMPWNCsMwavn", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"Bearer ya29.c.Kp8BFQgUT1EOcK5YBwTEv60KokPYvLLWJRFsbfd9S0oGEB3cW5cp1pXTJRZreYPB4B06Z1_YdvhLQByhe9fP_FjziQc6rCtEfGs9zZdMZpXKUFHWEqzG44qxni-jibwaLEgWLw3zaqv42y00x28jUmZQdP3AQilOPdn1xRwf6s-gWi_95d1t0qDe478VnclTIrZ_SmCMtDTTbdU1yvkA80TQ...", "User-Agent"=>"rest-client/2.0.2 (darwin19.6.0 x86_64) ruby/2.4.10p364"
+    RestClient.get "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/jobs/job_example123", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"Bearer <ACCESS_TOKEN>", "User-Agent"=>"rest-client/2.0.2 (darwin19.6.0 x86_64) ruby/2.4.10p364"
     # => 200 OK | application/json 2062 bytes
 
     OUTPUT

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__pick_lists.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__pick_lists.md
@@ -28,7 +28,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__test.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__test.md
@@ -54,7 +54,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'
@@ -501,7 +501,7 @@ Lastly, the Gem asks for permissions to override your settings file, which is sy
 ```ruby
  
     Updated settings file with new connection attributes? (Yes or No) Yes
-    RestClient.get "https://go.trackvia.com/openapi/views", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"Bearer new_valid_access_token", "User-Agent"=>"rest-client/2.0.2 (darwin19.6.0 x86_64) ruby/2.4.10p364"
+    RestClient.get "https://go.trackvia.com/openapi/views", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"Bearer <ACCESS_TOKEN>", "User-Agent"=>"rest-client/2.0.2 (darwin19.6.0 x86_64) ruby/2.4.10p364"
     # => 200 OK | application/json 65 bytes                
     Progress: |=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=---=|
 

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__triggers.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__cli__triggers.md
@@ -28,7 +28,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__rspec__connector_spec.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__rspec__connector_spec.md
@@ -22,7 +22,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__rspec__writing_tests.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__guides__rspec__writing_tests.md
@@ -22,7 +22,7 @@ The code in `connector.rb`.
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key'

--- a/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__reference__cli-commands.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-cli/references/cli__reference__cli-commands.md
@@ -13,11 +13,11 @@ Learn more about the commands you can use in CLI after installing the SDK gem.
 
 ## [#](<#workato>) workato
 
-Root command of the Workato gem. Synonymous with [`workato help`](<#workato-help>). 
+Root command of the Workato gem. Synonymous with [`workato help`](<#workato-help>).
 
 ### [#](<#usage>) Usage
 ```bash
- 
+
     $ workato
 
 
@@ -35,7 +35,7 @@ Creates or edits an encrypted file.
 
 ### [#](<#usage-2>) Usage
 ```bash
- 
+
     $ workato edit <PATH>
 
 
@@ -43,28 +43,28 @@ Creates or edits an encrypted file.
 
 ### [#](<#input>) Input
 
-Input | Description  
----|---  
-**EDITOR** | The editor you'll use to edit the file. For example: `nano`  
-**PATH** | The path to the file that should be created or updated, in dot notation.   
+Input | Description
+---|---
+**EDITOR** | The editor you'll use to edit the file. For example: `nano`
+**PATH** | The path to the file that should be created or updated, in dot notation.
 
 ### [#](<#options>) Options
 
-Option | Description  
----|---  
-**\--key, -k** | The path to the encrypt/decrypt key.  
+Option | Description
+---|---
+**\--key, -k** | The path to the encrypt/decrypt key.
 
-If this isn't provided, defaults to `master.key`.  
+If this isn't provided, defaults to `master.key`.
 
-If a `master.key` file doesn't exist and no option is provided, a new `master.key` file is created.   
+If a `master.key` file doesn't exist and no option is provided, a new `master.key` file is created.
 
 ### [#](<#result>) Result
 
-Encrypted file is created or updated. `master.key` is created if the file didn't previously exist and an option wasn't provided. 
+Encrypted file is created or updated. `master.key` is created if the file didn't previously exist and an option wasn't provided.
 
 ### [#](<#example>) Example
 ```ruby
- 
+
     For Windows:
       $ set EDITOR=notepad
       $ workato edit settings.yaml.enc
@@ -82,7 +82,7 @@ Executes a specific lambda function in your connector for testing.
 
 ### [#](<#usage-3>) Usage
 ```bash
- 
+
     $ workato exec <PATH> <OPTIONS>
 
 
@@ -90,80 +90,80 @@ Executes a specific lambda function in your connector for testing.
 
 ### [#](<#input-2>) Input
 
-Input | Description  
----|---  
-**PATH** | The path to the lambda to execute, in dot notation. For example: `actions.search_customers.execute` would correspond to the action `search_customers` and the execute lambda. You may also simulate the entire action with the path `actions.search_customers`.   
+Input | Description
+---|---
+**PATH** | The path to the lambda to execute, in dot notation. For example: `actions.search_customers.execute` would correspond to the action `search_customers` and the execute lambda. You may also simulate the entire action with the path `actions.search_customers`.
 
 ### [#](<#options-2>) Options
 
-Option | Description  
----|---  
-**-c or --connector** | The path to the `connector.rb` file to execute. Defaults to `connector.rb` if not provided.   
-**-s or --settings** | The path to the `settings.yaml` file that stores the credentials. Defaults to `settings.yaml.enc`, then `settings.yaml` if not provided.   
-**-n or --connection** | The connection name in the `settings.yaml` file. Only required if there are multiple credential sets.   
-**-i or --input** | The path to the JSON file that stores the input. Used for `execute`, `webhook_notification`, or `poll` lambdas.   
-**\--closure** | The path to the JSON file that stores the closure. Used for `poll` lambdas to simulate polls after the initial poll.   
-**-a or --args** | The path to the JSON file that stores arguments for a method or picklists. Used for `methods` or `pick_lists` lambdas to simulate their invocation. An error may arise if arguments were expected but not provided.   
-**\--extended-input-schema and --extended-output-schema** | The path to the JSON file that stores the `extended_input_schema` and `extended_output_schema`. Used for `execute`, `webhook_notification`, or `poll` lambdas.   
-**\--config-fields** | The path to the JSON file that stores the `config_fields` data. Used for `object_definitions`, `input_fields`, or `output_fields` lambdas.   
-**\--continue** | The path to the JSON file that store the `continue` data. Used for `execute` lambdas that have multistep implemented.   
-**\--from** | The starting byte range for a specific stream invocation. Used for `streams` lambdas.   
-**\--frame_size** | The requested framesize in bytes for a specific stream invocation. Used for `streams` lambdas.   
-**\--webhook-headers** | The path to the JSON file(s) that store incoming webhook header data. Used for `webhook_notification` lambdas.   
-**\--webhook-params** | The path to the JSON files that store incoming webhook parameter data. Used for `webhook_notification` lambdas.   
-**\--webhook-payload** | The path to the JSON files that store incoming webhook payload data. Used for `webhook_notification` lambdas.   
-**\--webhook-url** | The path to the file that stores the webhook URL. Used for `webhook_subscribe` lambdas.   
-**-o or --output** | The path to the file that saves the output of the lambda function.   
-**\--oauth2-code** | The OAuth2 code used to invoke the `acquire` lambda function.   
-**\--redirect-url** | The redirect-url used to invoke the `refresh` lambda function.   
-**\--refresh-token** | The refresh-token used to invoke the `refresh` lambda function.   
-**\--verbose** | Include this option to make the execution verbose. This means that all HTTP requests and request payloads will be shown. Response bodies won't be shown but can be inspected with `byebug`.   
-**\--debug** | Include this option to show errors from the entire stacktrace, rather than just the last encountered error.   
+Option | Description
+---|---
+**-c or --connector** | The path to the `connector.rb` file to execute. Defaults to `connector.rb` if not provided.
+**-s or --settings** | The path to the `settings.yaml` file that stores the credentials. Defaults to `settings.yaml.enc`, then `settings.yaml` if not provided.
+**-n or --connection** | The connection name in the `settings.yaml` file. Only required if there are multiple credential sets.
+**-i or --input** | The path to the JSON file that stores the input. Used for `execute`, `webhook_notification`, or `poll` lambdas.
+**\--closure** | The path to the JSON file that stores the closure. Used for `poll` lambdas to simulate polls after the initial poll.
+**-a or --args** | The path to the JSON file that stores arguments for a method or picklists. Used for `methods` or `pick_lists` lambdas to simulate their invocation. An error may arise if arguments were expected but not provided.
+**\--extended-input-schema and --extended-output-schema** | The path to the JSON file that stores the `extended_input_schema` and `extended_output_schema`. Used for `execute`, `webhook_notification`, or `poll` lambdas.
+**\--config-fields** | The path to the JSON file that stores the `config_fields` data. Used for `object_definitions`, `input_fields`, or `output_fields` lambdas.
+**\--continue** | The path to the JSON file that store the `continue` data. Used for `execute` lambdas that have multistep implemented.
+**\--from** | The starting byte range for a specific stream invocation. Used for `streams` lambdas.
+**\--frame_size** | The requested framesize in bytes for a specific stream invocation. Used for `streams` lambdas.
+**\--webhook-headers** | The path to the JSON file(s) that store incoming webhook header data. Used for `webhook_notification` lambdas.
+**\--webhook-params** | The path to the JSON files that store incoming webhook parameter data. Used for `webhook_notification` lambdas.
+**\--webhook-payload** | The path to the JSON files that store incoming webhook payload data. Used for `webhook_notification` lambdas.
+**\--webhook-url** | The path to the file that stores the webhook URL. Used for `webhook_subscribe` lambdas.
+**-o or --output** | The path to the file that saves the output of the lambda function.
+**\--oauth2-code** | The OAuth2 code used to invoke the `acquire` lambda function.
+**\--redirect-url** | The redirect-url used to invoke the `refresh` lambda function.
+**\--refresh-token** | The refresh-token used to invoke the `refresh` lambda function.
+**\--verbose** | Include this option to make the execution verbose. This means that all HTTP requests and request payloads will be shown. Response bodies won't be shown but can be inspected with `byebug`.
+**\--debug** | Include this option to show errors from the entire stacktrace, rather than just the last encountered error.
 
 ### [#](<#result-2>) Result
 
-The output of the lambda function. 
+The output of the lambda function.
 
 ### [#](<#examples>) Examples
 
 Invoke a specific method.
 ```bash
- 
+
     $ workato exec methods.sample_method --args='input/sample_method_input.json'
 
 ```
 
 Invoke the acquire lambda. Connector and settings are all specified.
 ```ruby
- 
+
     workato exec connection.authorization.acquire --connector='zoominfo.rb' --settings='settings.yaml' --connection='My Valid Connection' --verbose
 
 ```
 
 Invoke the test lambda. Connector and settings are all specified.
 ```ruby
- 
+
     workato exec test --connector='zoominfo.rb' --settings='settings.yaml' --connection='My Valid Connection' --verbose
 
 ```
 
 Invoke a specific action and pass it inputs.
 ```bash
- 
+
     $ workato exec actions.search_customers.execute --input='input/search_customer_input.json' --verbose
 
 ```
 
 Invoke a specific polling trigger and pass it inputs. This command simulates the trigger paginating through a series of records when `can_poll_more` is set to `true` in the closure.
 ```bash
- 
+
     $ workato exec triggers.new_updated_customers.poll --input='input/new_updated_customers_input.json' --verbose
 
 ```
 
 Invoke a specific polling trigger and pass it inputs. Output will be a single page of the poll. This command simulates a single trigger poll and returns only the first page.
 ```bash
- 
+
     $ workato exec triggers.new_updated_customers.poll_page --input='input/new_updated_customers_input.json' --verbose
 
 ```
@@ -172,11 +172,11 @@ Invoke a specific polling trigger and pass it inputs. Output will be a single pa
 
 ## [#](<#workato-generate>) workato generate
 
-Generates Workato schema based on a given JSON or CSV or tests based on a given connector 
+Generates Workato schema based on a given JSON or CSV or tests based on a given connector
 
 ### [#](<#usage-4>) Usage
 ```bash
- 
+
     $ workato generate <SUBCOMMAND>
 
 
@@ -184,19 +184,19 @@ Generates Workato schema based on a given JSON or CSV or tests based on a given 
 
 ### [#](<#input-3>) Input
 
-Input | Description  
----|---  
-**SUBCOMMAND** | The specific asset to be generated. Either `schema` or `test`.  
+Input | Description
+---|---
+**SUBCOMMAND** | The specific asset to be generated. Either `schema` or `test`.
 
 * * *
 
 ## [#](<#workato-generate-schema>) workato generate schema
 
-Takes a given JSON or CSV file and converts it into Workato Schema for use in your connector 
+Takes a given JSON or CSV file and converts it into Workato Schema for use in your connector
 
 ### [#](<#usage-5>) Usage
 ```bash
- 
+
     $ workato generate schema --api-token <API-TOKEN> <OPTIONS>
 
 
@@ -204,15 +204,15 @@ Takes a given JSON or CSV file and converts it into Workato Schema for use in yo
 
 ### [#](<#options-3>) Options
 
-Option | Description  
----|---  
-**\--json** | The path to the JSON file to convert into Workato Schema   
-**\--csv** | The path to the CSV file to convert into Workato Schema   
-**\--col-sep** | The column separators in the CSV file provided. Default: comma. Possible values: comma, space, tab, colon, semicolon, pipe   
-**\--api-email** | DEPRECATED. API email and keys authentication has been succeeded with API Client authentication that is more secure. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>). New versions of the SDK Gem will support deprecated API email and keys until 2023.   
-**\--api-token** | REQUIRED. The API token of an API client with the proper permissions. API email and keys authentication has been succeeded with API Client authentication that is more secure. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>).   
+Option | Description
+---|---
+**\--json** | The path to the JSON file to convert into Workato Schema
+**\--csv** | The path to the CSV file to convert into Workato Schema
+**\--col-sep** | The column separators in the CSV file provided. Default: comma. Possible values: comma, space, tab, colon, semicolon, pipe
+**\--api-email** | DEPRECATED. Use API Client token authentication instead. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>).
+**\--api-token** | REQUIRED unless `WORKATO_API_TOKEN` is set. The API token of an API client with the proper permissions. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>).
 
-Required API Client permissions: 
+Required API Client permissions:
 
   * POST /api/sdk/generate_schema/csv
   * POST /api/sdk/generate_schema/json
@@ -221,15 +221,15 @@ Required API Client permissions:
 
 Convert sample JSON payload to Workato schema
 ```bash
- 
-    $ workato generate schema --api-token --json='fixtures/actions/search_customers/input.json'
+
+    $ WORKATO_API_TOKEN=<API-TOKEN> workato generate schema --json='fixtures/actions/search_customers/input.json'
 
 ```
 
 Convert sample pipe delimited CSV file to Workato schema with
 ```bash
- 
-    $ workato generate schema --api-token --csv='fixtures/actions/report/input.csv' --col-sep=pipe
+
+    $ WORKATO_API_TOKEN=<API-TOKEN> workato generate schema --csv='fixtures/actions/report/input.csv' --col-sep=pipe
 
 ```
 
@@ -237,11 +237,11 @@ Convert sample pipe delimited CSV file to Workato schema with
 
 ## [#](<#workato-generate-test>) workato generate test
 
-Takes a given connector and generates RSpec tests for specified features. 
+Takes a given connector and generates RSpec tests for specified features.
 
 ### [#](<#usage-6>) Usage
 ```bash
- 
+
     $ workato generate test <OPTIONS>
 
 
@@ -249,27 +249,27 @@ Takes a given connector and generates RSpec tests for specified features.
 
 ### [#](<#options-4>) Options
 
-Option | Description  
----|---  
-**-c or --connector** | The path to the connector.rb file to execute. Defaults to connector.rb if not provided.   
-**-a or --action** | The name of the specific Action to generate tests for. Generates tests for all features if not specified.   
-**-t or --trigger** | The name of the specific Trigger to generate tests for. Generates tests for all features if not specified.   
-**-p or --pick-list** | The name of the specific picklist to generate tests for. Generates tests for all features if not specified.   
-**-o or --object-definition** | The name of the specific object_definition to generate tests for. Generates tests for all features if not specified.   
-**-m or --method** | The name of the specific method to generate tests for. Generates tests for all features if not specified.   
+Option | Description
+---|---
+**-c or --connector** | The path to the connector.rb file to execute. Defaults to connector.rb if not provided.
+**-a or --action** | The name of the specific Action to generate tests for. Generates tests for all features if not specified.
+**-t or --trigger** | The name of the specific Trigger to generate tests for. Generates tests for all features if not specified.
+**-p or --pick-list** | The name of the specific picklist to generate tests for. Generates tests for all features if not specified.
+**-o or --object-definition** | The name of the specific object_definition to generate tests for. Generates tests for all features if not specified.
+**-m or --method** | The name of the specific method to generate tests for. Generates tests for all features if not specified.
 
 ### [#](<#examples-3>) Examples
 
 Generate skeletal tests for all connector features
 ```bash
- 
+
     $ workato generate test
 
 ```
 
 Generate skeletal tests for specific action
 ```bash
- 
+
     $ workato generate test action=get_customers
 
 ```
@@ -282,7 +282,7 @@ Displays help for a specified SDK gem command.
 
 ### [#](<#usage-7>) Usage
 ```bash
- 
+
     $ workato help <COMMAND>
 
 
@@ -290,9 +290,9 @@ Displays help for a specified SDK gem command.
 
 ### [#](<#input-4>) Input
 
-Input | Description  
----|---  
-**COMMAND** | The command which you want to help displayed for. For example: `edit`  
+Input | Description
+---|---
+**COMMAND** | The command which you want to help displayed for. For example: `edit`
 
 ### [#](<#output-2>) Output
 
@@ -300,7 +300,7 @@ Elaborated help for the specified SDK gem command.
 
 ### [#](<#example-2>) Example
 ```bash
- 
+
     $ workato help edit
     Usage:
       workato edit PATH
@@ -318,11 +318,11 @@ Elaborated help for the specified SDK gem command.
 
 ## [#](<#workato-new>) workato new
 
-Creates a new connector project in your chosen directory.  
+Creates a new connector project in your chosen directory.
 
-When you create a new connector project, you will be asked if you want to select `secure` or `simple` for your HTTP mocking behavior: 
+When you create a new connector project, you will be asked if you want to select `secure` or `simple` for your HTTP mocking behavior:
 ```ruby
- 
+
     Please select default HTTP mocking behavior suitable for your project?
 
     1 - secure. Cause an error to be raised for any unknown requests, all request recordings are encrypted.
@@ -335,11 +335,11 @@ When you create a new connector project, you will be asked if you want to select
 
 ```
 
-When you select `secure`, VCR recordings made for your unit tests are encrypted. **This is recommended.** You'll need to set your environment variable for `VCR_RECORD_MODE` as well. 
+When you select `secure`, VCR recordings made for your unit tests are encrypted. **This is recommended.** You'll need to set your environment variable for `VCR_RECORD_MODE` as well.
 
 ### [#](<#usage-8>) Usage
 ```bash
- 
+
     $ workato new <PATH>
 
 
@@ -347,17 +347,17 @@ When you select `secure`, VCR recordings made for your unit tests are encrypted.
 
 ### [#](<#input-5>) Input
 
-Input | Description  
----|---  
-**PATH** | The path where the connector project should be created.   
+Input | Description
+---|---
+**PATH** | The path where the connector project should be created.
 
 ### [#](<#result-3>) Result
 
-Generates a new connector project. 
+Generates a new connector project.
 
 ### [#](<#example-3>) Example
 ```bash
- 
+
     $ workato new ~/Desktop/my-new-connector
 
 
@@ -371,11 +371,11 @@ GEM VERSION REQUIREMENT
 
 The command `workato oauth2` requires SDK Gem version 0.1.2 and above.
 
-Use this to implement the OAuth2 Authorization code grant flow for applicable connectors. Applicable connectors are ones where the connection hash has `type: 'oauth2`. For more information, check out this handy [Okta article](<https://developer.okta.com/blog/2018/04/10/oauth-authorization-code-grant-type>). 
+Use this to implement the OAuth2 Authorization code grant flow for applicable connectors. Applicable connectors are ones where the connection hash has `type: 'oauth2`. For more information, check out this handy [Okta article](<https://developer.okta.com/blog/2018/04/10/oauth-authorization-code-grant-type>).
 
 ### [#](<#usage-9>) Usage
 ```bash
- 
+
     $ workato oauth2 <OPTIONS>
 
 
@@ -383,28 +383,28 @@ Use this to implement the OAuth2 Authorization code grant flow for applicable co
 
 ### [#](<#options-5>) Options
 
-Option | Description  
----|---  
-**-c or --connector** | The path to the connector source code. Defaults to `connector.rb` if not provided.   
-**-s or --settings** | The path to the `settings.yaml` file that stores the credentials. Defaults to `settings.yaml.enc`, then `settings.yaml` if not provided.   
-**-n or --connection** | The connection name in the `settings.yaml` file. Only required if there are multiple credential sets.   
-**\--key, -k** | The path to the encrypt/decrypt key.  
+Option | Description
+---|---
+**-c or --connector** | The path to the connector source code. Defaults to `connector.rb` if not provided.
+**-s or --settings** | The path to the `settings.yaml` file that stores the credentials. Defaults to `settings.yaml.enc`, then `settings.yaml` if not provided.
+**-n or --connection** | The connection name in the `settings.yaml` file. Only required if there are multiple credential sets.
+**\--key, -k** | The path to the encrypt/decrypt key.
 
-If this isn't provided, defaults to `master.key`.  
+If this isn't provided, defaults to `master.key`.
 
-If a `master.key` file doesn't exist and no option is provided, a new `master.key` file is created.   
-**\--port** | By default, the SDK Gem spins up a webserver at "http://localhost:45555/oauth/callback" which is used to receive the OAuth callback. Use this option to change the port. i.e. --port='3010' will spin up the webserver at "http://localhost:3010/oauth/callback" This is useful when your OAuth app is configured to a specific redirect uri.   
-**\--ip** | Allows you to override the default ip address. Defaults to "127.0.0.1"   
-**\--https, --no-https** | Allows you to start the webserver with a self-signed certificate. Required in cases where the OAuth App requires a redirect uri with a "https://" prefix.   
-**\--verbose** | Include this option to make the execution verbose. This means that all HTTP requests and request payloads will be shown. Response bodies won't be shown but can be inspected with `byebug`.   
+If a `master.key` file doesn't exist and no option is provided, a new `master.key` file is created.
+**\--port** | By default, the SDK Gem spins up a webserver at "http://localhost:45555/oauth/callback" which is used to receive the OAuth callback. Use this option to change the port. i.e. --port='3010' will spin up the webserver at "http://localhost:3010/oauth/callback" This is useful when your OAuth app is configured to a specific redirect uri.
+**\--ip** | Allows you to override the default ip address. Defaults to "127.0.0.1"
+**\--https, --no-https** | Allows you to start the webserver with a self-signed certificate. Required in cases where the OAuth App requires a redirect uri with a "https://" prefix.
+**\--verbose** | Include this option to make the execution verbose. This means that all HTTP requests and request payloads will be shown. Response bodies won't be shown but can be inspected with `byebug`.
 
 ### [#](<#result-4>) Result
 
-Emulates the OAuth2 Authorization Code Grant Flow on Workato. Applicable connectors are ones where the connection hash has `type: 'oauth2`. For more information, check out this handy [Okta article](<https://developer.okta.com/blog/2018/04/10/oauth-authorization-code-grant-type>). 
+Emulates the OAuth2 Authorization Code Grant Flow on Workato. Applicable connectors are ones where the connection hash has `type: 'oauth2`. For more information, check out this handy [Okta article](<https://developer.okta.com/blog/2018/04/10/oauth-authorization-code-grant-type>).
 
 ### [#](<#example-4>) Example
 ```bash
- 
+
     $ workato oauth2
 
 
@@ -426,7 +426,7 @@ Creates a new connector project in your chosen Workato folder.
 
 ### [#](<#usage-10>) Usage
 ```bash
- 
+
     $ workato push --api-token <API-TOKEN> <OPTIONS>
 
 
@@ -434,31 +434,31 @@ Creates a new connector project in your chosen Workato folder.
 
 ### [#](<#options-6>) Options
 
-Option | Description  
----|---  
-**\--api-email** | DEPRECATED. API email and keys authentication has been succeeded with API Client authentication that is more secure. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>). New versions of the SDK Gem will support deprecated API email and keys until 2023.   
-**\--api-token** | REQUIRED. The API token of an API client with the proper permissions. API email and keys authentication has been succeeded with API Client authentication that is more secure. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>).   
+Option | Description
+---|---
+**\--api-email** | DEPRECATED. Use API Client token authentication instead. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>).
+**\--api-token** | REQUIRED unless `WORKATO_API_TOKEN` is set. The API token of an API client with the proper permissions. [Learn how to create an API client](<https://docs.workato.com/workato-api/api-clients.html#api-clients>).
 
-Required API Client permissions: 
+Required API Client permissions:
 
   * GET /api/users/me
   * GET /api/packages/:id
   * POST /api/packages/import/:id
 
-**\--folder** | The ID of the folder in your Workato workspace where you plan to push the connector. By default, the connector is not pushed to a specific folder unless you add the `--folder` parameter and folder ID.  
+**\--folder** | The ID of the folder in your Workato workspace where you plan to push the connector. By default, the connector is not pushed to a specific folder unless you add the `--folder` parameter and folder ID.
 
-Folder IDs are located in the URL when you're viewing the folder. For example: if the URL is `https://app.workato.com/?fid=106070#assets`, the folder ID is `106070`.   
-**-t or --title** | The title of your connector. Defaults to the title key in your connector code if not provided.   
-**-d or --description** | The path to your connector's description, which could be a Markdown or plain text file. Defaults to `README.md` if not provided.   
-**-l or --logo** | The link to the `png` or `jpeg` of your connector's logo. Defaults to `logo.png` if not provided.   
-**-n or --notes** | The version notes attached to this uploaded version.   
-**-c or --connector** | The path to the connector source code. Defaults to `connector.rb` if not provided.   
-**\--environment** | Use this data center-specific URL to push connector code. Defaults to the WORKATO_BASE_URL environment variable if not set. For example: \- `https://app.workato.com` \- `https://app.eu.workato.com` \- `https://app.jp.workato.com` \- `https://app.sg.workato.com` \- `https://app.au.workato.com` \- `https://app.il.workato.com` \- `https://app.trial.workato.com`   
+Folder IDs are located in the URL when you're viewing the folder. For example: if the URL is `https://app.workato.com/?fid=106070#assets`, the folder ID is `106070`.
+**-t or --title** | The title of your connector. Defaults to the title key in your connector code if not provided.
+**-d or --description** | The path to your connector's description, which could be a Markdown or plain text file. Defaults to `README.md` if not provided.
+**-l or --logo** | The link to the `png` or `jpeg` of your connector's logo. Defaults to `logo.png` if not provided.
+**-n or --notes** | The version notes attached to this uploaded version.
+**-c or --connector** | The path to the connector source code. Defaults to `connector.rb` if not provided.
+**\--environment** | Use this data center-specific URL to push connector code. Defaults to the WORKATO_BASE_URL environment variable if not set. For example: \- `https://app.workato.com` \- `https://app.eu.workato.com` \- `https://app.jp.workato.com` \- `https://app.sg.workato.com` \- `https://app.au.workato.com` \- `https://app.il.workato.com` \- `https://app.trial.workato.com`
 
 ### [#](<#example-5>) Example
 ```ruby
- 
-    workato push --api-token
+
+    WORKATO_API_TOKEN=<API-TOKEN> workato push
 
 
 ```

--- a/workato-connector-sdk/skills/workato-connector-sdk-reference/references/sdk-reference__connection.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-reference/references/sdk-reference__connection.md
@@ -71,7 +71,7 @@ References to any picklists you defined in your connector are not accessible in 
           {
             name: 'api_key',
             control_type: 'password',
-            hint: 'You can find your API key final change3' \
+            hint: 'You can find your API key' \
               "under 'Settings'=>'Configure Chargebee'=>'API Keys and Webhooks'" \
               " in Chargebee's web console.",
             label: 'Your API Key',


### PR DESCRIPTION
## Summary
- add Codex plugin metadata for workato-connector-sdk
- list workato-connector-sdk in the Codex marketplace
- correct stale SDK CLI guidance against the installed Ruby gem and current Workato docs
- scrub copied token/project examples and obvious artifact text from SDK references

## Validation
- jq empty .agents/plugins/marketplace.json workato-connector-sdk/.codex-plugin/plugin.json
- ruby SKILL.md frontmatter check
- claude plugin validate workato-connector-sdk
- claude plugin validate .
- git diff --check
- /Users/dave/.asdf/shims/workato version -> 1.3.19
- /Users/dave/.asdf/shims/workato help / help push checked for command surface
- hygiene scans for copied token/project examples and stale command claims