### PR TITLE
Expose Workato platform CLI plugin to Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -135,6 +135,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Integrations"
+    },
+    {
+      "name": "workato-platform-cli",
+      "source": {
+        "source": "local",
+        "path": "./workato-platform-cli"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -32,6 +32,7 @@ The tracked Codex marketplace exposes:
 | `workato-api` | Migrated | REST reference and curl/httpx execution patterns; credentials come from environment variables or gitignored local notes. |
 | `workato-recipe` | Migrated | Script-backed recipe analysis now uses the stable root CLI and avoids Claude-only path/subagent assumptions for Codex. |
 | `workato-connector-sdk` | Migrated | Documentation-heavy connector SDK plugin; stale CLI claims and copied token/project examples were corrected before exposure. |
+| `workato-platform-cli` | Migrated | Repo copy matches the installed user-level Codex skill; listed with explicit invocation policy because it can manage real Workato assets. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -49,7 +50,6 @@ scope decisions rather than mechanical manifest work.
 
 | Plugin | Status | Notes |
 | --- | --- | --- |
-| `workato-platform-cli` | Already exposed | A user-level Codex skill exists at `~/.codex/skills/workato-platform-cli/SKILL.md`. |
 | `playwright-cli` | Covered | A user-level Codex `playwright` skill already exists; migrate only if this repo plugin has distinct value. |
 | `cloudflare` | Partially covered | Codex has Cloudflare deployment/plugin support; this repo's MCP packaging needs a separate credential review. |
 

--- a/workato-platform-cli/.codex-plugin/plugin.json
+++ b/workato-platform-cli/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "workato-platform-cli",
+  "version": "0.1.0",
+  "description": "Workato Platform CLI guidance for managing workspace assets, recipes, connections, projects, and deployments.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "homepage": "https://pypi.org/project/workato-platform-cli/",
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/workato-platform-cli",
+  "keywords": [
+    "workato",
+    "platform-cli",
+    "recipes",
+    "connections",
+    "projects",
+    "deployment"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workato Platform CLI",
+    "shortDescription": "Manage Workato workspace assets through the Python CLI",
+    "longDescription": "Use Workato Platform CLI for installed-CLI command reference, workspace initialization, profile handling, project pull/push workflows, recipe lifecycle operations, connection management, API collections, API clients, properties, and data tables.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://pypi.org/project/workato-platform-cli/",
+    "defaultPrompt": [
+      "Use the Workato Platform CLI for this workspace task",
+      "Check the Workato Platform CLI command reference",
+      "Build a safe Workato CLI command"
+    ],
+    "brandColor": "#F45A2A",
+    "screenshots": []
+  }
+}

--- a/workato-platform-cli/skills/workato-platform-cli/agents/openai.yaml
+++ b/workato-platform-cli/skills/workato-platform-cli/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary
- add Codex plugin metadata for workato-platform-cli
- list workato-platform-cli in the Codex marketplace
- add explicit-invocation policy because the skill can manage real Workato assets

## Validation
- jq empty .agents/plugins/marketplace.json workato-platform-cli/.codex-plugin/plugin.json
- ruby YAML/frontmatter parse
- claude plugin validate workato-platform-cli
- claude plugin validate .
- git diff --check
- hygiene scans over new Codex files and marketplace/ledger changes