### PR TITLE
Document remaining Codex migration blockers

### DIFF
--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -57,16 +57,18 @@ scope decisions rather than mechanical manifest work.
 
 These should not be mechanically exposed by adding manifests only.
 
-| Plugin group | Reason |
-| --- | --- |
-| `agents`, `staff-software-engineer` | Claude subagent definitions are not equivalent to Codex plugin skills. |
-| `issue-blaster`, `scraper-generator` | Include Claude subagents and workflow assumptions that need Codex-native rewrite. |
-| `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Many include placeholder connector or MCP expectations; review `.mcp.json` and decide Codex app/MCP mapping first. |
-| `google-workspace` | Large recipe surface; likely valuable, but needs connector/auth strategy before listing. |
-| `cloudflare`, `namecheap` | MCP server packaging and credential setup need Codex manifest and install-path review. |
-| `jq-for-clawd` | Claude session-history assumptions need a Codex session-log rewrite. |
-| `dev-browser` | Overlaps existing browser tooling and needs runtime/tooling validation. |
-| `espanso`, `karabiner-elements` | Likely personal machine-automation skills rather than public marketplace plugins. |
+| Plugin group | Required action before listing | Why it is blocked |
+| --- | --- | --- |
+| `agents`, `staff-software-engineer` | Rewrite useful agent prompts as Codex skills with `SKILL.md`; keep Claude-only agent files out of Codex manifests. | These plugins are agent-definition bundles, and Claude subagent metadata is not a Codex plugin interface. |
+| `issue-blaster`, `scraper-generator` | Replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end issue/scraper flow. | Both plugins mix skills with Claude agents and assume delegation surfaces that Codex will not load as plugin skills. |
+| `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | For each domain pack, map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
+| `google-workspace` | Split the large recipe surface into safe read-only, write/send, and watch/automation groups; map each group to Codex Google connectors or MCP dependencies before listing. | The plugin has many action-oriented recipes with different auth and side-effect profiles, so one manifest policy is too coarse. |
+| `cloudflare`, `namecheap` | Verify local MCP server packaging, npm package names, lockfile choice, env vars, and Codex MCP startup behavior; then add manifests with explicit env requirements. | These ship MCP servers and credentials, not only skills. The install path must work before marketplace exposure. |
+| `context7` | Add or declare a Codex-compatible Context7 MCP dependency, or rewrite the skill to route through an available docs tool. | The skill instructs the agent to call Context7 tools, but this repo plugin does not currently provide the MCP server config. |
+| `jq-for-clawd` | Fork into a Claude session-history skill and a Codex session-history skill; rewrite the Codex variant for `~/.codex/sessions` and Codex rollout JSONL structure. | Current instructions hard-code Claude Code session paths and message schema. |
+| `dev-browser` | Decide whether it supersedes, complements, or should be retired in favor of the existing Chrome/browser tooling; if kept, run its build/test suite and validate extension startup. | It is a full browser-extension/runtime project, not a simple skill bundle, and it overlaps existing Codex browser capabilities. |
+| `espanso`, `karabiner-elements` | Decide whether these belong in the public marketplace or should remain personal user-local skills; if listed, mark explicit-invocation-only and validate macOS config backup/restore behavior. | They modify local machine automation state and include user-environment assumptions. |
+| `playwright-cli` | Keep covered unless a concrete gap versus the installed Codex `playwright` skill appears; if a gap exists, migrate only that distinct workflow. | The current Codex environment already has a Playwright skill, so listing another browser automation plugin risks duplicate triggers. |
 
 ## Migration Rules
 


### PR DESCRIPTION
## Summary
- replace broad remaining-work buckets with concrete action requirements per plugin group
- clarify which plugins need Codex skill rewrites, connector/MCP mapping, runtime validation, or personal-scope decisions before listing

## Validation
- git diff --check
- claude plugin validate .