### PR TITLE
Add plugin repository validator and residency inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,24 @@ Not every plugin uses all component types.
 
 **Never commit real org IDs, email addresses, company names, or credentials to this repo.** User-specific data goes in `.local.md` files (gitignored) or user-level skills (`~/.claude/skills/` or `~/.codex/skills/`). Evaluate real-looking examples case-by-case before scrubbing them; preserve utility, but prefer `example.com` / fictional data for public plugin content.
 
+### Repository Residency
+
+Repo membership is an explicit decision, not a fixed constraint. During cleanup,
+classify each asset before publishing, adapting, or deleting it:
+
+| Status | Meaning | Action |
+| --- | --- | --- |
+| `public-marketplace` | Generic enough to publish from this repo. | Keep tracked, list in the Claude marketplace, and add Codex metadata only after review. |
+| `needs-generalization` | Useful, but currently has personal or local assumptions. | Rewrite with public defaults plus env/userConfig/local overlays before listing broadly. |
+| `split-public-private` | Has a reusable public core and private user-specific values. | Keep the reusable core here; move private values to `.local.md`, user skills, local plugin config, or a private repo. |
+| `personal-local` | Valuable to Dave, but not a public marketplace asset. | Remove from the tracked marketplace/repo after preserving it in a local Claude/Codex install location or private repo. |
+| `parked` | Potentially useful, but blocked by architecture, auth, overlap, or unclear value. | Keep documented in the migration ledger, but do not list or adapt until the blocker is resolved. |
+
+Removing an asset from this repo is allowed when classification calls for it,
+but do it deliberately: remove marketplace entries, preserve a recoverable copy
+outside the repo when it is still personally useful, and record the destination
+or reason in the relevant migration ledger.
+
 ### Decision Tree
 
 ```
@@ -110,9 +128,12 @@ Does it contain PII, org IDs, credentials, or company-specific data?
 
 ### Pre-Commit Checks
 
-Before committing, verify no PII in tracked files:
+Before committing, run the repository validator and verify no PII in tracked
+files:
 
 ```bash
+ruby scripts/validate_repo.rb
+
 # Check tracked files for email addresses (excluding example.com and plugin infra files)
 git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' | rg -v '@example|AGENTS.md'
 git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' '*.json' | rg -v '@example|AGENTS.md|plugin.json|marketplace.json'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,24 @@ Not every plugin uses all component types.
 
 **Never commit real org IDs, email addresses, company names, or credentials to this repo.** User-specific data goes in `.local.md` files (gitignored) or `~/.claude/skills/`. Evaluate real-looking examples case-by-case before scrubbing them; preserve utility, but prefer `example.com` / fictional data for public plugin content.
 
+### Repository Residency
+
+Repo membership is an explicit decision, not a fixed constraint. During cleanup,
+classify each asset before publishing, adapting, or deleting it:
+
+| Status | Meaning | Action |
+| --- | --- | --- |
+| `public-marketplace` | Generic enough to publish from this repo. | Keep tracked, list in the Claude marketplace, and add Codex metadata only after review. |
+| `needs-generalization` | Useful, but currently has personal or local assumptions. | Rewrite with public defaults plus env/userConfig/local overlays before listing broadly. |
+| `split-public-private` | Has a reusable public core and private user-specific values. | Keep the reusable core here; move private values to `.local.md`, user skills, local plugin config, or a private repo. |
+| `personal-local` | Valuable to Dave, but not a public marketplace asset. | Remove from the tracked marketplace/repo after preserving it in a local Claude/Codex install location or private repo. |
+| `parked` | Potentially useful, but blocked by architecture, auth, overlap, or unclear value. | Keep documented in the migration ledger, but do not list or adapt until the blocker is resolved. |
+
+Removing an asset from this repo is allowed when classification calls for it,
+but do it deliberately: remove marketplace entries, preserve a recoverable copy
+outside the repo when it is still personally useful, and record the destination
+or reason in the relevant migration ledger.
+
 ### Decision Tree
 
 ```
@@ -101,9 +119,12 @@ Does it contain PII, org IDs, credentials, or company-specific data?
 
 ### Pre-Commit Checks
 
-Before committing, verify no PII in tracked files:
+Before committing, run the repository validator and verify no PII in tracked
+files:
 
 ```bash
+ruby scripts/validate_repo.rb
+
 # Check tracked files for email addresses (excluding example.com and plugin infra files)
 git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' | rg -v '@example|CLAUDE.md'
 git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' '*.json' | rg -v '@example|CLAUDE.md|plugin.json|marketplace.json'

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -38,6 +38,26 @@ The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
 and should be treated as reference material only.
 
+## Repository Residency
+
+Codex migration is downstream of cleanup. Cleanup can mean keeping a plugin in
+this repository, splitting a public core from private overlays, or removing a
+plugin from the repository entirely after preserving it somewhere appropriate.
+
+Use these statuses while reviewing every asset:
+
+| Status | Meaning | Typical destination |
+| --- | --- | --- |
+| `public-marketplace` | Generic, reusable, and appropriate for this public marketplace. | Keep in repo; list in `.claude-plugin/marketplace.json`; add Codex metadata only after review. |
+| `needs-generalization` | Useful, but not yet safe or general enough for a public marketplace. | Rewrite with env/userConfig/local overlays, then reclassify. |
+| `split-public-private` | Public core is useful, but user-specific data or defaults must move out. | Public core in repo; private values in `.local.md`, user skills, local plugin config, or private repo. |
+| `personal-local` | Useful personally, but not a marketplace asset. | `~/.claude/skills/`, local Claude plugin install, `~/.codex/skills/`, or a private repo. |
+| `parked` | Not ready to publish or adapt because value, overlap, auth, or architecture is unresolved. | Keep documented here until deliberately resumed or removed. |
+
+When a plugin becomes `personal-local`, remove it from the tracked marketplace
+and, if the content is still useful, preserve a recoverable copy outside this
+repo before deleting the tracked tree.
+
 ## Candidate Review
 
 ### Direct Or Near-Direct Candidates
@@ -70,14 +90,36 @@ These should not be mechanically exposed by adding manifests only.
 | `espanso`, `karabiner-elements` | Decide whether these belong in the public marketplace or should remain personal user-local skills; if listed, mark explicit-invocation-only and validate macOS config backup/restore behavior. | They modify local machine automation state and include user-environment assumptions. |
 | `playwright-cli` | Keep covered unless a concrete gap versus the installed Codex `playwright` skill appears; if a gap exists, migrate only that distinct workflow. | The current Codex environment already has a Playwright skill, so listing another browser automation plugin risks duplicate triggers. |
 
+### Initial Residency Calls
+
+These are working classifications, not final deletion decisions:
+
+| Plugin or group | Current residency call | Cleanup implication |
+| --- | --- | --- |
+| Migrated Codex plugins in the current marketplace | `public-marketplace` or accepted public/personal hybrid | Keep listed; continue validating mechanically. |
+| `terminal-tidbits` | `split-public-private` | Public skill stays here; personal notes stay outside the plugin directory. |
+| `salesforce-soql` | `split-public-private` | Public SOQL and CLI workflows stay here; org schemas remain ignored/local unless sanitized examples are deliberate. |
+| `cloudflare`, `namecheap` | `needs-generalization` | Keep only if the MCP servers can be generalized without losing personal utility; otherwise preserve locally/private and remove from the public marketplace. |
+| Domain MCP packs | `needs-generalization` | Preserve Claude MCP parity first; do not substitute native Codex apps silently. Open issues for cases where a native Codex connector is materially better. |
+| `google-workspace` | `needs-generalization` | Review the existing Claude behavior and side effects before any Codex listing; split only if the current asset already implies distinct risk surfaces. |
+| `jq-for-clawd` | `split-public-private` candidate | Keep a Claude session-history skill; add a separate Codex session-history variant if useful. |
+| `espanso`, `karabiner-elements` | `personal-local` candidate | Likely move out of the public marketplace unless they are rewritten as generic, explicit-invocation macOS config workflows. |
+| `dev-browser`, `playwright-cli` | `parked` | Do not list unless they provide a concrete gap over existing browser tooling. |
+| `agents`, `staff-software-engineer` | `parked` | Rewrite only the useful prompts as skills when there is a current use case. |
+
 ## Migration Rules
 
 - Add a plugin to `.agents/plugins/marketplace.json` only after its
   `.codex-plugin/plugin.json`, skill metadata, and runtime assumptions have been
   reviewed.
+- Preserve the existing Claude asset architecture by default. Do not replace an
+  MCP-backed Claude workflow with a native Codex app/connector unless there is a
+  documented reason; open a GitHub issue for those exceptions.
 - Prefer `skills/<skill>/agents/openai.yaml` for Codex-only invocation policy
   instead of overloading Claude-specific frontmatter.
 - Do not copy personal author emails into Codex manifests.
 - Keep Codex migration PRs separate from Claude cleanup PRs.
 - Validate both surfaces when a plugin remains dual-use: `claude plugin
   validate <plugin>` for Claude and JSON/YAML/frontmatter checks for Codex.
+- Run `ruby scripts/validate_repo.rb` before proposing or merging repository
+  metadata changes.

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -1,0 +1,56 @@
+# MCP Inventory
+
+This inventory reflects the tracked `.mcp.json` files in this repository. It is
+not a Codex migration approval list. Preserve Claude MCP parity by default; if a
+native Codex app/connector looks materially better for a specific dependency,
+open a GitHub issue instead of silently substituting it.
+
+## Current Servers
+
+| Server | Kind | Current config | Used by | Env vars | Current disposition |
+| --- | --- | --- | --- | --- | --- |
+| `amplitude` | HTTP MCP | `https://mcp.amplitude.com/mcp` | `data`, `product-management` |  | Claude MCP parity review required |
+| `apollo` | HTTP MCP | `https://api.apollo.io/mcp` | `sales` |  | Claude MCP parity review required |
+| `asana` | HTTP MCP | `https://mcp.asana.com/v2/mcp` | `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity` |  | Claude MCP parity review required |
+| `atlassian` | HTTP MCP | `https://mcp.atlassian.com/v1/mcp` | `data`, `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `bigquery` | HTTP MCP | `https://bigquery.googleapis.com/mcp` | `data`, `finance` |  | Claude MCP parity review required |
+| `clay` | HTTP MCP | `https://api.clay.com/v3/mcp` | `sales` |  | Claude MCP parity review required |
+| `clickup` | HTTP MCP | `https://mcp.clickup.com/mcp` | `product-management`, `productivity` |  | Claude MCP parity review required |
+| `close` | HTTP MCP | `https://mcp.close.com/mcp` | `sales` |  | Claude MCP parity review required |
+| `cloudflare` | local npm MCP | `npx -y @grailautomation/cloudflare-mcp` | `cloudflare` | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` | Generalize or move to personal/private install |
+| `datadog` | HTTP MCP | `https://mcp.datadoghq.com/mcp` | `engineering` |  | Claude MCP parity review required |
+| `docusign` | HTTP MCP | `https://mcp.docusign.com/mcp` | `legal` |  | Claude MCP parity review required |
+| `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Claude MCP parity review required |
+| `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Claude MCP parity review required |
+| `github` | HTTP MCP | `https://api.github.com/mcp` | `engineering` |  | Claude MCP parity review required |
+| `gmail` | HTTP MCP | `https://gmail.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `google-calendar` | HTTP MCP | `https://gcal.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `google-drive` | HTTP MCP | `https://google-drive-mcp.claude.com/mcp` | `legal` |  | Claude MCP parity review required |
+| `guru` | HTTP MCP | `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Claude MCP parity review required |
+| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Claude MCP parity review required |
+| `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Claude MCP parity review required |
+| `intercom` | HTTP MCP | `https://mcp.intercom.com/mcp` | `design`, `product-management` |  | Claude MCP parity review required |
+| `linear` | HTTP MCP | `https://mcp.linear.app/mcp` | `design`, `engineering`, `product-management`, `productivity` |  | Claude MCP parity review required |
+| `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Claude MCP parity review required |
+| `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `namecheap` | local npm MCP | `npx -y @grailautomation/namecheap-mcp` | `namecheap` | `NAMECHEAP_API_KEY`, `NAMECHEAP_API_USER`, `NAMECHEAP_USERNAME` | Generalize or move to personal/private install |
+| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Claude MCP parity review required |
+| `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Claude MCP parity review required |
+| `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Claude MCP parity review required |
+| `servicenow` | HTTP MCP | `https://mcp.servicenow.com/mcp` | `operations` |  | Claude MCP parity review required |
+| `similarweb` | HTTP MCP | `https://mcp.similarweb.com/mcp` | `product-management`, `sales` |  | Claude MCP parity review required |
+| `slack` | HTTP MCP | `https://mcp.slack.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `zoominfo` | HTTP MCP | `https://mcp.zoominfo.com/mcp` | `sales` |  | Claude MCP parity review required |
+
+## Review Rules
+
+- Do not list connector-heavy plugins for Codex by adding manifests only.
+- Keep the current Claude MCP architecture as the default source of truth.
+- For HTTP MCP servers, verify Codex runtime support, auth setup, and side
+  effects before listing the owning plugin.
+- For local npm MCP servers, verify package name, package manager/lockfile,
+  environment variables, and startup behavior before deciding whether the plugin
+  is public or personal/local.
+- For Google and Microsoft endpoints, call out any proposed native Codex
+  connector substitution in a GitHub issue before changing the migration plan.

--- a/scripts/validate_repo.rb
+++ b/scripts/validate_repo.rb
@@ -10,14 +10,9 @@ require "yaml"
 ROOT = Pathname.new(File.expand_path("..", __dir__))
 
 errors = []
-warnings = []
 
 error = lambda do |path, message|
   errors << [path, message]
-end
-
-warn = lambda do |path, message|
-  warnings << [path, message]
 end
 
 repo_path = lambda do |relative_path|
@@ -327,11 +322,6 @@ files.grep(/\.md\z/).each do |relative_path|
       error.call("#{relative_path}:#{line_number}", "hardcoded user path: #{user_path}")
     end
   end
-end
-
-unless warnings.empty?
-  puts "Warnings:"
-  warnings.each { |path, message| puts "  #{path}: #{message}" }
 end
 
 if errors.empty?

--- a/scripts/validate_repo.rb
+++ b/scripts/validate_repo.rb
@@ -1,0 +1,343 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+require "set"
+require "uri"
+require "yaml"
+
+ROOT = Pathname.new(File.expand_path("..", __dir__))
+
+errors = []
+warnings = []
+
+error = lambda do |path, message|
+  errors << [path, message]
+end
+
+warn = lambda do |path, message|
+  warnings << [path, message]
+end
+
+repo_path = lambda do |relative_path|
+  ROOT + relative_path
+end
+
+read_json = lambda do |relative_path|
+  JSON.parse(repo_path.call(relative_path).read)
+rescue JSON::ParserError => e
+  error.call(relative_path, "invalid JSON: #{e.message}")
+  nil
+end
+
+read_yaml = lambda do |relative_path, content|
+  YAML.safe_load(content, aliases: true)
+rescue Psych::Exception => e
+  error.call(relative_path, "invalid YAML: #{e.message}")
+  nil
+end
+
+extract_frontmatter = lambda do |relative_path|
+  content = repo_path.call(relative_path).read
+  lines = content.lines
+
+  unless lines.first&.strip == "---"
+    error.call(relative_path, "missing YAML frontmatter")
+    return nil
+  end
+
+  body = []
+  lines.drop(1).each do |line|
+    return body.join if line.strip == "---"
+
+    body << line
+  end
+
+  error.call(relative_path, "missing closing YAML frontmatter fence")
+  nil
+end
+
+git_files_output = IO.popen(
+  ["git", "-C", ROOT.to_s, "ls-files", "-co", "--exclude-standard"],
+  &:read
+)
+files = git_files_output.lines.map(&:chomp).reject(&:empty?).sort
+
+json_cache = {}
+files.grep(/\.json\z/).each do |relative_path|
+  json_cache[relative_path] = read_json.call(relative_path)
+end
+
+files.grep(/\.(ya?ml)\z/).each do |relative_path|
+  read_yaml.call(relative_path, repo_path.call(relative_path).read)
+end
+
+codex_plugin_files = files.select { |path| path.include?("/.codex-plugin/") }
+codex_plugin_files.each do |relative_path|
+  next if relative_path.end_with?("/.codex-plugin/plugin.json")
+
+  error.call(relative_path, "only plugin.json belongs under .codex-plugin/")
+end
+
+skill_files = files.select { |path| path.match?(%r{\A[^/]+/skills/[^/]+/SKILL\.md\z}) }
+skill_files.each do |relative_path|
+  frontmatter = extract_frontmatter.call(relative_path)
+  next unless frontmatter
+
+  metadata = read_yaml.call(relative_path, frontmatter)
+  unless metadata.is_a?(Hash)
+    error.call(relative_path, "frontmatter must be a mapping")
+    next
+  end
+
+  skill_dir_name = relative_path.split("/")[-2]
+  declared_name = metadata["name"]
+  description = metadata["description"]
+
+  if declared_name.to_s.strip.empty?
+    error.call(relative_path, "frontmatter must include name")
+  elsif declared_name != skill_dir_name
+    error.call(relative_path, "frontmatter name must match skill directory '#{skill_dir_name}'")
+  end
+
+  error.call(relative_path, "frontmatter must include description") if description.to_s.strip.empty?
+end
+
+markdown_link = /!?\[[^\]]*\]\(([^)]+)\)/
+files.grep(/\.md\z/).each do |relative_path|
+  repo_path.call(relative_path).each_line.with_index(1) do |line, line_number|
+    line.scan(markdown_link) do |match|
+      raw_target = match.first.strip
+      target =
+        if raw_target.start_with?("<") && raw_target.include?(">")
+          raw_target[1...raw_target.index(">")]
+        else
+          raw_target.split(/\s+/, 2).first
+        end
+
+      next if target.nil? || target.empty?
+      next if target.start_with?("#")
+      next if target.match?(%r{\A[a-zA-Z][a-zA-Z0-9+.-]*:})
+
+      target_path = target.split("#", 2).first
+      next if target_path.empty?
+      next if target_path.start_with?("/")
+      next unless target_path.match?(%r{(^|/|^\./|^\.\./)references/}) || target_path.end_with?(".md", ".markdown")
+
+      decoded_target =
+        begin
+          URI.decode_www_form_component(target_path)
+        rescue ArgumentError
+          target_path
+        end
+
+      destination =
+        if Pathname.new(decoded_target).absolute?
+          Pathname.new(decoded_target)
+        else
+          repo_path.call(File.dirname(relative_path)) + decoded_target
+        end
+
+      next if destination.exist?
+
+      error.call("#{relative_path}:#{line_number}", "broken relative markdown link: #{target}")
+    end
+  end
+end
+
+claude_marketplace_path = ".claude-plugin/marketplace.json"
+codex_marketplace_path = ".agents/plugins/marketplace.json"
+
+unless json_cache[claude_marketplace_path].is_a?(Hash)
+  error.call(claude_marketplace_path, "Claude marketplace is missing or invalid")
+end
+
+unless json_cache[codex_marketplace_path].is_a?(Hash)
+  error.call(codex_marketplace_path, "Codex marketplace is missing or invalid")
+end
+
+validate_unique_names = lambda do |entries, path|
+  names = Set.new
+  entries.each do |entry|
+    name = entry["name"]
+    if name.to_s.strip.empty?
+      error.call(path, "marketplace entry is missing name")
+    elsif names.include?(name)
+      error.call(path, "duplicate marketplace entry: #{name}")
+    else
+      names.add(name)
+    end
+  end
+end
+
+if (marketplace = json_cache[claude_marketplace_path])
+  entries = marketplace["plugins"]
+  if entries.is_a?(Array)
+    validate_unique_names.call(entries, claude_marketplace_path)
+
+    entries.each do |entry|
+      name = entry["name"]
+      source = entry["source"]
+
+      unless source.is_a?(String) && source.start_with?("./")
+        error.call(claude_marketplace_path, "#{name || "<unnamed>"} source must start with ./")
+        next
+      end
+
+      plugin_dir = source.delete_prefix("./")
+      unless repo_path.call(plugin_dir).directory?
+        error.call(claude_marketplace_path, "#{name} source directory does not exist: #{source}")
+        next
+      end
+
+      manifest_path = "#{plugin_dir}/.claude-plugin/plugin.json"
+      unless repo_path.call(manifest_path).file?
+        error.call(claude_marketplace_path, "#{name} is missing #{manifest_path}")
+        next
+      end
+
+      manifest = json_cache[manifest_path] || read_json.call(manifest_path)
+      manifest_name = manifest&.fetch("name", nil)
+      error.call(manifest_path, "manifest name must match marketplace name '#{name}'") if manifest_name && manifest_name != name
+    end
+  else
+    error.call(claude_marketplace_path, "plugins must be an array")
+  end
+end
+
+codex_listed_plugin_dirs = Set.new
+if (marketplace = json_cache[codex_marketplace_path])
+  entries = marketplace["plugins"]
+  if entries.is_a?(Array)
+    validate_unique_names.call(entries, codex_marketplace_path)
+
+    entries.each do |entry|
+      name = entry["name"]
+      source = entry["source"]
+      source_path = source.is_a?(Hash) ? source["path"] : nil
+
+      unless source.is_a?(Hash) && source["source"] == "local"
+        error.call(codex_marketplace_path, "#{name || "<unnamed>"} source must be local")
+        next
+      end
+
+      unless source_path.is_a?(String) && source_path.start_with?("./")
+        error.call(codex_marketplace_path, "#{name || "<unnamed>"} source.path must start with ./")
+        next
+      end
+
+      plugin_dir = source_path.delete_prefix("./")
+      codex_listed_plugin_dirs.add(plugin_dir)
+
+      unless repo_path.call(plugin_dir).directory?
+        error.call(codex_marketplace_path, "#{name} source directory does not exist: #{source_path}")
+        next
+      end
+
+      manifest_path = "#{plugin_dir}/.codex-plugin/plugin.json"
+      unless repo_path.call(manifest_path).file?
+        error.call(codex_marketplace_path, "#{name} is missing #{manifest_path}")
+        next
+      end
+
+      manifest = json_cache[manifest_path] || read_json.call(manifest_path)
+      next unless manifest
+
+      manifest_name = manifest["name"]
+      error.call(manifest_path, "manifest name must match marketplace name '#{name}'") if manifest_name != name
+
+      if repo_path.call("#{plugin_dir}/skills").directory? && manifest["skills"].to_s.strip.empty?
+        error.call(manifest_path, "Codex manifest must expose skills when plugin has a skills directory")
+      end
+
+      manifest_text = JSON.generate(manifest)
+      if manifest_text.match?(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/)
+        error.call(manifest_path, "Codex manifest must not contain personal email addresses")
+      end
+    end
+  else
+    error.call(codex_marketplace_path, "plugins must be an array")
+  end
+end
+
+codex_manifests = files.select { |path| path.match?(%r{\A[^/]+/\.codex-plugin/plugin\.json\z}) }
+codex_manifests.each do |manifest_path|
+  plugin_dir = manifest_path.split("/", 2).first
+  next if codex_listed_plugin_dirs.include?(plugin_dir)
+
+  error.call(manifest_path, "Codex manifest exists but plugin is not listed in #{codex_marketplace_path}")
+end
+
+mcp_files = files.select { |path| path.end_with?("/.mcp.json") }
+mcp_files.each do |relative_path|
+  config = json_cache[relative_path]
+  servers = config&.fetch("mcpServers", nil)
+  unless servers.is_a?(Hash) && !servers.empty?
+    error.call(relative_path, "mcpServers must be a non-empty object")
+    next
+  end
+
+  servers.each do |server_name, server_config|
+    unless server_config.is_a?(Hash)
+      error.call(relative_path, "#{server_name} config must be an object")
+      next
+    end
+
+    has_command = server_config["command"].is_a?(String)
+    has_http = server_config["type"].is_a?(String) && server_config["url"].is_a?(String)
+
+    unless has_command || has_http
+      error.call(relative_path, "#{server_name} must declare either command or type/url")
+    end
+
+    args = server_config["args"]
+    error.call(relative_path, "#{server_name} args must be an array when present") if args && !args.is_a?(Array)
+
+    env = server_config["env"]
+    error.call(relative_path, "#{server_name} env must be an object when present") if env && !env.is_a?(Hash)
+  end
+end
+
+email_pattern = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/
+files.grep(/\.(md|json)\z/).each do |relative_path|
+  next if relative_path.end_with?("plugin.json")
+  next if relative_path.end_with?("marketplace.json")
+  next if ["AGENTS.md", "CLAUDE.md"].include?(relative_path)
+
+  repo_path.call(relative_path).each_line.with_index(1) do |line, line_number|
+    line.scan(email_pattern).each do |email|
+      next if email.include?("@example")
+
+      error.call("#{relative_path}:#{line_number}", "possible real email address: #{email}")
+    end
+  end
+end
+
+files.grep(/\.md\z/).each do |relative_path|
+  repo_path.call(relative_path).each_line.with_index(1) do |line, line_number|
+    line.scan(/00D[A-Za-z0-9]{15}/).each do |org_id|
+      next if org_id.start_with?("00D000000000000")
+      next if line.include?("data:image")
+
+      error.call("#{relative_path}:#{line_number}", "possible Salesforce org ID: #{org_id}")
+    end
+
+    line.scan(%r{/Users/[a-z][A-Za-z0-9_-]*}).each do |user_path|
+      error.call("#{relative_path}:#{line_number}", "hardcoded user path: #{user_path}")
+    end
+  end
+end
+
+unless warnings.empty?
+  puts "Warnings:"
+  warnings.each { |path, message| puts "  #{path}: #{message}" }
+end
+
+if errors.empty?
+  puts "OK: validated #{files.length} files, #{skill_files.length} skills, #{mcp_files.length} MCP configs"
+else
+  puts "Errors:"
+  errors.each { |path, message| puts "  #{path}: #{message}" }
+  exit 1
+end

--- a/workato-connector-sdk/skills/workato-connector-sdk-data-formats/references/guides__data-formats__request_format_multipart_form.md
+++ b/workato-connector-sdk/skills/workato-connector-sdk-data-formats/references/guides__data-formats__request_format_multipart_form.md
@@ -91,7 +91,7 @@ cURL | Workato
 ---|---  
 `curl https://gateway.watsonplatform.net/document-conversion/api/v1/convert_document?version=2015-12-15 -X POST` | `post("https://gateway.watsonplatform.net/document-conversion/api/v1/convert_document")`  
 `.params(version: "2015-12-15")`  
-`-u "{username}":"{password}"` | This is defined in the [connection](../authentication/basic-authentication.md) key and is automatically added onto the outgoing request.  
+`-u "{username}":"{password}"` | This is defined in the [connection](../../workato-connector-sdk-authentication/references/guides__authentication__basic-authentication.md) key and is automatically added onto the outgoing request.
 `-F config="{\"conversion_target\":\"answer_units\"}"`  
 `-F "[[email protected]](</cdn-cgi/l/email-protection>);type=application/pdf"` | `.request_format_multipart_form`  
 `.payload(`  


### PR DESCRIPTION
## Summary
- add a Ruby validator for plugin repo structure, frontmatter, marketplaces, MCP configs, hygiene scans, and broken local reference links
- document public/private repository residency outcomes in AGENTS.md, CLAUDE.md, and CODEX_MIGRATION.md
- add an MCP inventory ledger and fix one broken Workato connector SDK reference link found by the validator

## Validation
- ruby scripts/validate_repo.rb
- ruby -c scripts/validate_repo.rb
- git diff --check
- claude plugin validate workato-connector-sdk (passes with existing no-version warning)
- hygiene greps from AGENTS.md/CLAUDE.md