### PR TITLE
Split Codex session history skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -183,6 +183,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Reference"
+    },
+    {
+      "name": "codex-session-history",
+      "source": {
+        "source": "local",
+        "path": "./codex-session-history"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -36,6 +36,7 @@ The tracked Codex marketplace exposes:
 | `cloudflare` | Migrated | Public MCP-backed infrastructure plugin; credentials stay in environment variables; published `npx` MCP startup lists 28 tools. |
 | `namecheap` | Migrated | Public MCP-backed registrar/DNS plugin; credentials and whitelisted IPs stay outside the repo; published `npx` MCP startup lists 8 tools. |
 | `context7` | Migrated | Public MCP-backed docs plugin; ships Context7 MCP config and current tool schema; published `npx` MCP startup lists `resolve-library-id` and `query-docs`. |
+| `codex-session-history` | Migrated | Codex-specific split from `jq-for-clawd`; uses `~/.codex/sessions` and `~/.codex/archived_sessions` JSONL shapes instead of Claude Code's project session layout. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -86,7 +87,6 @@ These should not be mechanically exposed by adding manifests only.
 | `issue-blaster`, `scraper-generator` | Replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end issue/scraper flow. | Both plugins mix skills with Claude agents and assume delegation surfaces that Codex will not load as plugin skills. |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | For each domain pack, map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
 | `google-workspace` | Split the large recipe surface into safe read-only, write/send, and watch/automation groups; map each group to Codex Google connectors or MCP dependencies before listing. | The plugin has many action-oriented recipes with different auth and side-effect profiles, so one manifest policy is too coarse. |
-| `jq-for-clawd` | Fork into a Claude session-history skill and a Codex session-history skill; rewrite the Codex variant for `~/.codex/sessions` and Codex rollout JSONL structure. | Current instructions hard-code Claude Code session paths and message schema. |
 | `dev-browser` | Decide whether it supersedes, complements, or should be retired in favor of the existing Chrome/browser tooling; if kept, run its build/test suite and validate extension startup. | It is a full browser-extension/runtime project, not a simple skill bundle, and it overlaps existing Codex browser capabilities. |
 | `espanso`, `karabiner-elements` | Decide whether these belong in the public marketplace or should remain personal user-local skills; if listed, mark explicit-invocation-only and validate macOS config backup/restore behavior. | They modify local machine automation state and include user-environment assumptions. |
 | `playwright-cli` | Keep covered unless a concrete gap versus the installed Codex `playwright` skill appears; if a gap exists, migrate only that distinct workflow. | The current Codex environment already has a Playwright skill, so listing another browser automation plugin risks duplicate triggers. |
@@ -103,7 +103,7 @@ These are working classifications, not final deletion decisions:
 | `cloudflare`, `namecheap` | `public-marketplace` | Keep in the public Claude marketplace. Credentials, account IDs, whitelisted IPs, and domain lists stay outside the repo in environment variables, account settings, Claude/Codex config, or gitignored local notes. |
 | Domain MCP packs | `needs-generalization` | Preserve Claude MCP parity first; do not substitute native Codex apps silently. Open issues for cases where a native Codex connector is materially better. |
 | `google-workspace` | `needs-generalization` | Review the existing Claude behavior and side effects before any Codex listing; split only if the current asset already implies distinct risk surfaces. |
-| `jq-for-clawd` | `split-public-private` candidate | Keep a Claude session-history skill; add a separate Codex session-history variant if useful. |
+| `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
 | `espanso`, `karabiner-elements` | `personal-local` candidate | Likely move out of the public marketplace unless they are rewritten as generic, explicit-invocation macOS config workflows. |
 | `dev-browser`, `playwright-cli` | `parked` | Do not list unless they provide a concrete gap over existing browser tooling. |
 | `agents`, `staff-software-engineer` | `parked` | Rewrite only the useful prompts as skills when there is a current use case. |

--- a/codex-session-history/.codex-plugin/plugin.json
+++ b/codex-session-history/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "codex-session-history",
+  "version": "0.1.0",
+  "description": "Query Codex session JSONL history with jq to find past conversations, tool calls, and task context.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/codex-session-history",
+  "keywords": [
+    "codex",
+    "session-history",
+    "jq",
+    "jsonl",
+    "debugging"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Codex Session History",
+    "shortDescription": "Search Codex session JSONL",
+    "longDescription": "Use Codex Session History to query local Codex session JSONL with jq while avoiding oversized prompt, image, and metadata dumps.",
+    "developerName": "Grail Automation",
+    "category": "Productivity",
+    "capabilities": [
+      "Read"
+    ],
+    "defaultPrompt": [
+      "Search my Codex session history for this topic",
+      "Show recent Codex sessions in this repo",
+      "Find Codex tool calls related to this error"
+    ],
+    "brandColor": "#111827",
+    "screenshots": []
+  }
+}

--- a/codex-session-history/skills/codex-session-history/SKILL.md
+++ b/codex-session-history/skills/codex-session-history/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: codex-session-history
+description: Query local Codex session history with jq. Use when users explicitly ask to search Codex sessions, inspect prior Codex conversations, find previous user messages, locate tool calls, summarize past work by working directory, or query Codex rollout JSONL files.
+---
+
+# Codex Session History
+
+Use this skill when the user explicitly asks to inspect local Codex session history. Codex session files can contain private prompts, screenshots, tool outputs, and credentials accidentally pasted by a user, so extract only the fields needed to answer the request.
+
+## Session Locations
+
+Codex stores active session JSONL files under date-partitioned directories:
+
+```bash
+~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+```
+
+Older sessions may be archived flat under:
+
+```bash
+~/.codex/archived_sessions/rollout-*.jsonl
+```
+
+Memory summaries under `~/.codex/memories/rollout_summaries/` are derived summaries, not raw session logs. Use them only when the user asks for memory-derived history or when raw session search is too broad.
+
+## JSONL Structure
+
+Each line is a JSON object. Common top-level `type` values:
+
+| Type | Useful fields | Notes |
+| --- | --- | --- |
+| `session_meta` | `.payload.id`, `.payload.cwd`, `.payload.originator`, `.payload.cli_version`, `.payload.source`, `.payload.model_provider` | Also may contain large instructions; do not print the full payload by default. |
+| `turn_context` | `.payload.turn_id`, `.payload.cwd`, `.payload.current_date`, `.payload.model`, `.payload.summary` | Marks turn boundaries and compaction context. |
+| `event_msg` | `.payload.type`, plus event-specific fields | Includes `user_message`, `agent_message`, `task_started`, `task_complete`, `token_count`, and patch events. |
+| `response_item` | `.payload.type`, `.payload.role`, `.payload.content`, `.payload.name`, `.payload.arguments` | Stores model messages, reasoning, function calls, and tool outputs. |
+
+Common `response_item.payload.type` values include `message`, `reasoning`, `function_call`, `function_call_output`, `custom_tool_call`, and `custom_tool_call_output`.
+
+## Safe Search Defaults
+
+- Prefer field extraction with `jq`; avoid raw `cat`, `head`, or `grep` over full files.
+- Skip or summarize `session_meta.payload.base_instructions`, large image payloads, and full tool outputs unless the user explicitly needs them.
+- Use `--arg` for user-provided search text instead of interpolating it into jq programs.
+- Truncate message/tool excerpts in exploratory commands.
+- Report file paths and timestamps so the user can request a deeper follow-up.
+
+## Find Session Files
+
+Recent active sessions:
+
+```bash
+find "$HOME/.codex/sessions" -name '*.jsonl' -type f -print0 |
+  xargs -0 ls -t |
+  head -20
+```
+
+Recent active and archived sessions together:
+
+```bash
+find "$HOME/.codex/sessions" "$HOME/.codex/archived_sessions" \
+  -name '*.jsonl' -type f -print0 2>/dev/null |
+  xargs -0 ls -t |
+  head -30
+```
+
+Sessions for a working directory:
+
+```bash
+TARGET_CWD="$PWD"
+find "$HOME/.codex/sessions" "$HOME/.codex/archived_sessions" \
+  -name '*.jsonl' -type f -print0 2>/dev/null |
+  while IFS= read -r -d '' f; do
+    jq -e --arg cwd "$TARGET_CWD" '
+      select(.type == "session_meta" and .payload.cwd == $cwd)
+    ' "$f" >/dev/null 2>&1 && printf '%s\n' "$f"
+  done |
+  xargs ls -t 2>/dev/null |
+  head -20
+```
+
+## Inspect File Shape
+
+Count top-level line types:
+
+```bash
+jq -r '.type // "<missing>"' "$SESSION_FILE" | sort | uniq -c
+```
+
+Count response item types:
+
+```bash
+jq -r '
+  select(.type == "response_item") |
+  .payload.type // "<missing>"
+' "$SESSION_FILE" | sort | uniq -c
+```
+
+Show safe metadata:
+
+```bash
+jq -c '
+  select(.type == "session_meta") |
+  {
+    timestamp,
+    id: .payload.id,
+    cwd: .payload.cwd,
+    originator: .payload.originator,
+    cli_version: .payload.cli_version,
+    source: .payload.source,
+    model_provider: .payload.model_provider
+  }
+' "$SESSION_FILE"
+```
+
+## Extract Messages
+
+User messages from the event stream:
+
+```bash
+jq -r '
+  select(.type == "event_msg" and .payload.type == "user_message") |
+  .timestamp + " | " + (.payload.message // "" | gsub("\n"; " ") | .[0:300])
+' "$SESSION_FILE"
+```
+
+Assistant final/intermediate messages from the event stream:
+
+```bash
+jq -r '
+  select(.type == "event_msg" and .payload.type == "agent_message") |
+  .timestamp + " | " + ((.payload.phase // "agent") + " | " + (.payload.message // "" | gsub("\n"; " ") | .[0:300]))
+' "$SESSION_FILE"
+```
+
+Messages from response items:
+
+```bash
+jq -r '
+  def content_text:
+    if (.payload.content | type) == "array" then
+      [.payload.content[]? | .text // .input_text // empty] | join(" ")
+    elif (.payload.content | type) == "string" then
+      .payload.content
+    else
+      ""
+    end;
+
+  select(.type == "response_item" and .payload.type == "message") |
+  .timestamp + " | " + (.payload.role // "unknown") + " | " + (content_text | gsub("\n"; " ") | .[0:300])
+' "$SESSION_FILE"
+```
+
+## Search By Keyword
+
+Search user and assistant event messages across active and archived sessions:
+
+```bash
+QUERY="keyword"
+find "$HOME/.codex/sessions" "$HOME/.codex/archived_sessions" \
+  -name '*.jsonl' -type f -print0 2>/dev/null |
+  while IFS= read -r -d '' f; do
+    jq -r --arg q "$QUERY" --arg file "$f" '
+      select(
+        .type == "event_msg" and
+        (.payload.type == "user_message" or .payload.type == "agent_message") and
+        ((.payload.message // "") | test($q; "i"))
+      ) |
+      $file + "\t" + .timestamp + "\t" + .payload.type + "\t" +
+      ((.payload.message // "") | gsub("\n"; " ") | .[0:240])
+    ' "$f" 2>/dev/null
+  done
+```
+
+Search response item text while avoiding session metadata:
+
+```bash
+QUERY="keyword"
+jq -r --arg q "$QUERY" '
+  def content_text:
+    if (.payload.content | type) == "array" then
+      [.payload.content[]? | .text // .input_text // empty] | join(" ")
+    elif (.payload.content | type) == "string" then
+      .payload.content
+    else
+      ""
+    end;
+
+  select(.type == "response_item" and .payload.type == "message") |
+  content_text as $text |
+  select($text | test($q; "i")) |
+  .timestamp + " | " + (.payload.role // "unknown") + " | " + ($text | gsub("\n"; " ") | .[0:240])
+' "$SESSION_FILE"
+```
+
+## Tool Calls
+
+List function calls without full arguments:
+
+```bash
+jq -r '
+  select(.type == "response_item" and .payload.type == "function_call") |
+  .timestamp + " | " + (.payload.name // "tool") + " | " + (.payload.call_id // "")
+' "$SESSION_FILE"
+```
+
+Find calls to a specific tool:
+
+```bash
+TOOL_NAME="exec_command"
+jq -r --arg tool "$TOOL_NAME" '
+  select(
+    .type == "response_item" and
+    .payload.type == "function_call" and
+    .payload.name == $tool
+  ) |
+  .timestamp + " | " + (.payload.call_id // "") + " | " + ((.payload.arguments // "") | tostring | gsub("\n"; " ") | .[0:300])
+' "$SESSION_FILE"
+```
+
+List tool outputs by call id without printing full output:
+
+```bash
+jq -r '
+  select(.type == "response_item" and .payload.type == "function_call_output") |
+  .timestamp + " | " + (.payload.call_id // "") + " | " + ((.payload.output // "") | tostring | gsub("\n"; " ") | .[0:220])
+' "$SESSION_FILE"
+```
+
+## Typical Workflow
+
+When the user asks to find prior Codex work:
+
+1. Identify whether they mean the current repository, a date range, a keyword, or a specific task.
+2. List likely session files by modification time, or filter by `session_meta.payload.cwd`.
+3. Count line types in one representative file before extracting details.
+4. Search `event_msg` user and assistant messages first; use `response_item` for deeper reconstruction.
+5. Return a compact answer with timestamps, matching excerpts, and the session file paths used.

--- a/codex-session-history/skills/codex-session-history/agents/openai.yaml
+++ b/codex-session-history/skills/codex-session-history/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/jq-for-clawd/.claude-plugin/plugin.json
+++ b/jq-for-clawd/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "jq-for-clawd",
   "description": "Query Claude Code session history using jq to find past conversations and user messages",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "keywords": ["session-history", "jq", "conversations", "debugging"]
 }

--- a/jq-for-clawd/README.md
+++ b/jq-for-clawd/README.md
@@ -23,13 +23,13 @@ When users ask about past conversations, previous sessions, or want to search th
 
 ## Installation
 
-Add this plugin to Claude Code:
+Add this plugin to Claude Code for a single session:
 
 ```bash
-claude --plugin-dir ~/Documents/DEV/claude-plugins/jq-for-clawd
+claude --plugin-dir /path/to/claude-plugins/jq-for-clawd
 ```
 
-Or symlink into your plugins directory.
+Or install it from the configured Claude plugin marketplace.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- keep `jq-for-clawd` Claude-specific, but scrub its personal author email and hardcoded local install path
- add a separate `codex-session-history` Codex plugin for `~/.codex/sessions` and `~/.codex/archived_sessions` JSONL
- list the Codex plugin in `.agents/plugins/marketplace.json` and mark the split complete in `CODEX_MIGRATION.md`

## Validation
- `ruby scripts/validate_repo.rb`
- `ruby -c scripts/validate_repo.rb`
- `jq empty .agents/plugins/marketplace.json codex-session-history/.codex-plugin/plugin.json jq-for-clawd/.claude-plugin/plugin.json`
- `git diff --check`
- `claude plugin validate jq-for-clawd` (passes with existing no-version warning)
- jq extraction snippets smoke-tested against a real local Codex session file without dumping raw session contents
