### PR TITLE
Harden macOS config plugin safeguards

### DIFF
--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -88,7 +88,6 @@ These should not be mechanically exposed by adding manifests only.
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | For each domain pack, map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
 | `google-workspace` | Split the large recipe surface into safe read-only, write/send, and watch/automation groups; map each group to Codex Google connectors or MCP dependencies before listing. | The plugin has many action-oriented recipes with different auth and side-effect profiles, so one manifest policy is too coarse. |
 | `dev-browser` | Decide whether it supersedes, complements, or should be retired in favor of the existing Chrome/browser tooling; if kept, run its build/test suite and validate extension startup. | It is a full browser-extension/runtime project, not a simple skill bundle, and it overlaps existing Codex browser capabilities. |
-| `espanso`, `karabiner-elements` | Decide whether these belong in the public marketplace or should remain personal user-local skills; if listed, mark explicit-invocation-only and validate macOS config backup/restore behavior. | They modify local machine automation state and include user-environment assumptions. |
 | `playwright-cli` | Keep covered unless a concrete gap versus the installed Codex `playwright` skill appears; if a gap exists, migrate only that distinct workflow. | The current Codex environment already has a Playwright skill, so listing another browser automation plugin risks duplicate triggers. |
 
 ### Initial Residency Calls
@@ -104,7 +103,7 @@ These are working classifications, not final deletion decisions:
 | Domain MCP packs | `needs-generalization` | Preserve Claude MCP parity first; do not substitute native Codex apps silently. Open issues for cases where a native Codex connector is materially better. |
 | `google-workspace` | `needs-generalization` | Review the existing Claude behavior and side effects before any Codex listing; split only if the current asset already implies distinct risk surfaces. |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
-| `espanso`, `karabiner-elements` | `personal-local` candidate | Likely move out of the public marketplace unless they are rewritten as generic, explicit-invocation macOS config workflows. |
+| `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |
 | `dev-browser`, `playwright-cli` | `parked` | Do not list unless they provide a concrete gap over existing browser tooling. |
 | `agents`, `staff-software-engineer` | `parked` | Rewrite only the useful prompts as skills when there is a current use case. |
 

--- a/espanso/skills/espanso/SKILL.md
+++ b/espanso/skills/espanso/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: espanso
+user-invocable: true
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
 description: >
   Espanso text expander configuration, match authoring, and workflow automation on macOS.
   Use when the user asks to: create or edit espanso matches/triggers, set up text snippets,
@@ -15,6 +17,14 @@ description: >
 Espanso is a cross-platform text expander written in Rust. It intercepts keystrokes and
 replaces trigger strings with defined expansions. Config is YAML-based.
 
+## Safety Rules
+
+- Treat Espanso config as user machine state. Read the current config before editing it.
+- Resolve the config directory from `ESPANSO_CONFIG_DIR` when set; otherwise use the macOS default path.
+- Back up the specific file you will edit before making changes.
+- Ask before replacing an existing trigger or adding a shell/script expansion with side effects.
+- Prefer focused edits to one match file instead of rewriting the full config tree.
+
 ## Config Locations (macOS)
 
 | File | Purpose |
@@ -23,7 +33,16 @@ replaces trigger strings with defined expansions. Config is YAML-based.
 | `$CONFIG/match/base.yml` | Default matches (always active) |
 | `$CONFIG/match/packages/` | Third-party packages |
 
-`$CONFIG` = `~/Library/Application Support/espanso`
+`$CONFIG` = `${ESPANSO_CONFIG_DIR:-$HOME/Library/Application Support/espanso}`
+
+Back up a match file before editing:
+
+```bash
+CONFIG="${ESPANSO_CONFIG_DIR:-$HOME/Library/Application Support/espanso}"
+TARGET="$CONFIG/match/base.yml"
+mkdir -p "$CONFIG/backups"
+cp "$TARGET" "$CONFIG/backups/$(basename "$TARGET").$(date +%Y%m%d%H%M%S).bak"
+```
 
 ## Core Concepts
 
@@ -38,7 +57,7 @@ replaces trigger strings with defined expansions. Config is YAML-based.
 ```yaml
 matches:
   - trigger: ":sig"
-    replace: "Best Regards,\nDave"
+    replace: "Best regards,\nYour Name"
 
   # word: true — only fires when surrounded by word separators
   - trigger: "teh"
@@ -102,7 +121,7 @@ Forms prompt the user with a popup before expanding.
 
 ```yaml
   - trigger: ":email"
-    replace: "Hi {{form1.name}},\n\n{{form1.body}}\n\nBest,\nDave"
+    replace: "Hi {{form1.name}},\n\n{{form1.body}}\n\nBest,\nYour Name"
     vars:
       - name: form1
         type: form
@@ -154,7 +173,9 @@ match/
 
 ## Workflow
 
-1. Edit any file under `$CONFIG/match/` — espanso auto-reloads on save
-2. Config changes (`$CONFIG/config/`) require `espanso restart`
-3. Use `espanso match list` to verify a trigger is registered
-4. Use `espanso log` to debug unexpected behavior
+1. Resolve `$CONFIG` and inspect the target match/config file
+2. Back up the target file before editing
+3. Edit one focused file under `$CONFIG/match/` when adding snippets
+4. Restart Espanso after config changes under `$CONFIG/config/`
+5. Use `espanso match list` to verify a trigger is registered
+6. Use `espanso log` to debug unexpected behavior

--- a/karabiner-elements/.claude-plugin/plugin.json
+++ b/karabiner-elements/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "karabiner-elements",
   "description": "Karabiner-Elements configuration and keyboard customization for macOS",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/karabiner-elements/skills/karabiner-elements/SKILL.md
+++ b/karabiner-elements/skills/karabiner-elements/SKILL.md
@@ -2,6 +2,7 @@
 name: karabiner-elements
 version: 0.1.0
 user-invocable: true
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
 description: >-
   This skill should be used when the user asks to "remap keys", "set up a
   hyper key", "create Karabiner rules", "configure keyboard shortcuts",
@@ -14,13 +15,22 @@ description: >-
 
 Configure, customize, and troubleshoot Karabiner-Elements on macOS — including key remapping, complex modifications, profiles, and device-specific rules.
 
+## Safety Rules
+
+- Treat Karabiner configuration as user machine state. Read the current config before editing it.
+- Resolve paths from environment variables when set; otherwise use Karabiner's macOS defaults.
+- Back up `karabiner.json` before any write.
+- Prefer adding focused complex modification files over rewriting unrelated profile data.
+- Lint complex modifications with `karabiner_cli` when the CLI is available.
+- Do not run uninstall, root-owned environment-file edits, or other destructive maintenance commands unless the user explicitly asks for that action.
+
 ## Important Paths
 
 ```
-CONFIG_FILE: ~/.config/karabiner/karabiner.json
-COMPLEX_MODS_DIR: ~/.config/karabiner/assets/complex_modifications/
-CLI_PATH: /Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli
-DEVICES_FILE: ~/.local/share/karabiner/karabiner_grabber_devices.json
+CONFIG_FILE: ${KARABINER_CONFIG_FILE:-$HOME/.config/karabiner/karabiner.json}
+COMPLEX_MODS_DIR: ${KARABINER_COMPLEX_MODS_DIR:-$HOME/.config/karabiner/assets/complex_modifications}
+CLI_PATH: ${KARABINER_CLI_PATH:-/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli}
+DEVICES_FILE: ${KARABINER_DEVICES_FILE:-$HOME/.local/share/karabiner/karabiner_grabber_devices.json}
 LOG_DIR: /var/log/karabiner/
 ```
 
@@ -50,19 +60,19 @@ The main `karabiner.json` structure:
 
 ```bash
 # Profile management
-'$CLI_PATH' --list-profile-names
-'$CLI_PATH' --show-current-profile-name
-'$CLI_PATH' --select-profile 'Profile Name'
+"$CLI_PATH" --list-profile-names
+"$CLI_PATH" --show-current-profile-name
+"$CLI_PATH" --select-profile 'Profile Name'
 
 # Variable management
-'$CLI_PATH' --set-variables '{"my_var":1, "another_var":true}'
+"$CLI_PATH" --set-variables '{"my_var":1, "another_var":true}'
 
 # Configuration validation
-'$CLI_PATH' --lint-complex-modifications "~/.config/karabiner/assets/complex_modifications/*.json"
+"$CLI_PATH" --lint-complex-modifications "$COMPLEX_MODS_DIR"/*.json
 
 # Version and help
-'$CLI_PATH' --version
-'$CLI_PATH' --help
+"$CLI_PATH" --version
+"$CLI_PATH" --help
 ```
 
 ## Environment Inspection

--- a/karabiner-elements/skills/karabiner-elements/scripts/config_manager.py
+++ b/karabiner-elements/skills/karabiner-elements/scripts/config_manager.py
@@ -5,15 +5,24 @@ Safe utilities for reading and modifying Karabiner configurations.
 """
 
 import json
+import os
 import sys
 import shutil
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, Dict, Any, List
 
-CONFIG_PATH = Path.home() / '.config/karabiner/karabiner.json'
-COMPLEX_MODS_DIR = Path.home() / '.config/karabiner/assets/complex_modifications'
-BACKUP_DIR = Path.home() / '.config/karabiner/backups'
+def env_path(name: str, default: Path) -> Path:
+    """Resolve a path from an environment override or a default."""
+    return Path(os.environ.get(name, str(default))).expanduser()
+
+
+CONFIG_PATH = env_path('KARABINER_CONFIG_FILE', Path.home() / '.config/karabiner/karabiner.json')
+COMPLEX_MODS_DIR = env_path(
+    'KARABINER_COMPLEX_MODS_DIR',
+    Path.home() / '.config/karabiner/assets/complex_modifications',
+)
+BACKUP_DIR = env_path('KARABINER_BACKUP_DIR', Path.home() / '.config/karabiner/backups')
 
 def backup_config() -> Path:
     """Create a timestamped backup of the current config."""

--- a/karabiner-elements/skills/karabiner-elements/scripts/inspect_environment.sh
+++ b/karabiner-elements/skills/karabiner-elements/scripts/inspect_environment.sh
@@ -3,9 +3,9 @@
 # Gathers information about the current Karabiner configuration
 set -uo pipefail
 
-CLI_PATH="/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli"
-CONFIG_PATH="$HOME/.config/karabiner/karabiner.json"
-DEVICES_PATH="$HOME/.local/share/karabiner/karabiner_grabber_devices.json"
+CLI_PATH="${KARABINER_CLI_PATH:-/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli}"
+CONFIG_PATH="${KARABINER_CONFIG_FILE:-$HOME/.config/karabiner/karabiner.json}"
+DEVICES_PATH="${KARABINER_DEVICES_FILE:-$HOME/.local/share/karabiner/karabiner_grabber_devices.json}"
 
 echo "=== Karabiner-Elements Environment Report ==="
 echo ""


### PR DESCRIPTION
## Summary
- keep `espanso` and `karabiner-elements` in the public Claude marketplace as generic macOS config workflows
- add explicit invocation/tool metadata and backup-first safety guidance before writing local machine config
- scrub the remaining personal author metadata from `karabiner-elements` and add env-overridable Karabiner paths
- mark the macOS config residency decision complete in `CODEX_MIGRATION.md`

## Validation
- `ruby scripts/validate_repo.rb`
- `python3 -m py_compile karabiner-elements/skills/karabiner-elements/scripts/config_manager.py`
- `bash -n karabiner-elements/skills/karabiner-elements/scripts/inspect_environment.sh`
- `git diff --check`
- `claude plugin validate espanso` (passes with existing no-version warning)
- `claude plugin validate karabiner-elements` (passes with existing no-version warning)
- temp-file smoke test for Karabiner list/backup/inspection paths without touching real config
