### PR TITLE
Scrub manifest author emails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ ruby scripts/validate_repo.rb
 
 # Check tracked files for email addresses (excluding example.com and plugin infra files)
 git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' | rg -v '@example|AGENTS.md'
-git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' '*.json' | rg -v '@example|AGENTS.md|plugin.json|marketplace.json'
+git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' '*.json' | rg -v '@example|AGENTS.md|marketplace.json'
 
 # Check for Salesforce org IDs
 git grep -n -E '00D[A-Za-z0-9]{15}' -- '*.md' | rg -v '00D000000000000|data:image'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ ruby scripts/validate_repo.rb
 
 # Check tracked files for email addresses (excluding example.com and plugin infra files)
 git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' | rg -v '@example|CLAUDE.md'
-git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' '*.json' | rg -v '@example|CLAUDE.md|plugin.json|marketplace.json'
+git grep -n -E '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' -- '*.md' '*.json' | rg -v '@example|CLAUDE.md|marketplace.json'
 
 # Check for Salesforce org IDs
 git grep -n -E '00D[A-Za-z0-9]{15}' -- '*.md' | rg -v '00D000000000000|data:image'

--- a/agents/.claude-plugin/plugin.json
+++ b/agents/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "agents",
   "description": "Reusable subagent definitions for common development workflows",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "keywords": ["agents", "subagents", "workflows"]
 }

--- a/dev-browser/.claude-plugin/plugin.json
+++ b/dev-browser/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "dev-browser",
   "description": "Browser automation skill with persistent page state for developers and AI agents",
   "author": {
-    "name": "Sawyer Hood",
-    "email": "sawyerjhood@gmail.com"
+    "name": "Sawyer Hood"
   },
   "keywords": ["browser", "playwright", "automation", "testing", "debugging"]
 }

--- a/google-workspace/.claude-plugin/plugin.json
+++ b/google-workspace/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "google-workspace",
   "description": "Google Workspace CLI (gws) skills for Gmail, Drive, Calendar, Sheets, Docs, Slides, Chat, Meet, Tasks, Forms, Keep, and cross-service workflows",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/issue-blaster/.claude-plugin/plugin.json
+++ b/issue-blaster/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "issue-blaster",
   "description": "Analyze GitHub issues and implement AI-generated solution plans (pure plugin - no Python required)",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "repository": "https://github.com/kreitter/claude-plugins",
   "keywords": ["github", "issues", "automation", "planning", "implementation"]

--- a/oasb-scaffold/.claude-plugin/plugin.json
+++ b/oasb-scaffold/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "oasb-scaffold",
   "description": "OASBuilder pipeline package conventions for scaffolding new stages",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "keywords": ["oasbuilder", "openapi", "pipeline", "scaffolding", "python"]
 }

--- a/openapi-spec-generation/.claude-plugin/plugin.json
+++ b/openapi-spec-generation/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "openapi-spec-generation",
   "description": "OpenAPI 3.1 specification generation, validation, and SDK workflows",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/python-patterns/.claude-plugin/plugin.json
+++ b/python-patterns/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "python-patterns",
   "description": "Idiomatic Python patterns, best practices, and code review reference",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/python-quickbooks/.claude-plugin/plugin.json
+++ b/python-quickbooks/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "python-quickbooks",
   "description": "Comprehensive reference for the python-quickbooks library (ej2/python-quickbooks) — QuickBooks Online API integration in Python.",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/salesforce-soql/.claude-plugin/plugin.json
+++ b/salesforce-soql/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "salesforce-soql",
   "description": "Salesforce data operations using the sf CLI: SOQL queries, schema exploration, and Bulk API 2.0 write operations (import, update, upsert, delete).",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/scraper-generator/.claude-plugin/plugin.json
+++ b/scraper-generator/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "scraper-generator",
   "description": "Generate custom API documentation scrapers through guided discovery and code generation",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/scripts/validate_repo.rb
+++ b/scripts/validate_repo.rb
@@ -326,7 +326,6 @@ end
 
 email_pattern = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/
 files.grep(/\.(md|json)\z/).each do |relative_path|
-  next if relative_path.end_with?("plugin.json")
   next if relative_path.end_with?("marketplace.json")
   next if ["AGENTS.md", "CLAUDE.md"].include?(relative_path)
 

--- a/spec-kit/.claude-plugin/plugin.json
+++ b/spec-kit/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "spec-kit",
   "description": "Spec-Driven Development toolkit — generate thorough specs, plans, and tasks for any project",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "repository": "https://github.com/spec-kit/spec-kit",
   "keywords": ["spec", "planning", "sdd", "tasks", "specification", "implementation"]

--- a/staff-software-engineer/.claude-plugin/plugin.json
+++ b/staff-software-engineer/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "staff-software-engineer",
   "description": "Staff software engineer agent for reviewing implementation plans",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "keywords": ["review", "planning", "architecture"]
 }

--- a/terminal-tidbits/.claude-plugin/plugin.json
+++ b/terminal-tidbits/.claude-plugin/plugin.json
@@ -2,8 +2,7 @@
   "name": "terminal-tidbits",
   "description": "Personal reference system for terminal commands and concepts you're learning",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   },
   "keywords": ["terminal", "learning", "reference", "commands", "shell"]
 }

--- a/uv-package-manager/.claude-plugin/plugin.json
+++ b/uv-package-manager/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "uv-package-manager",
   "description": "uv package manager for fast Python dependency management and project workflows",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/workato-api/.claude-plugin/plugin.json
+++ b/workato-api/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "workato-api",
   "description": "Workato Developer API reference and execution framework for managing workspace resources via REST",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/workato-connector-sdk/.claude-plugin/plugin.json
+++ b/workato-connector-sdk/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "workato-connector-sdk",
   "description": "Workato Connector SDK documentation for building custom connectors",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/workato-platform-cli/.claude-plugin/plugin.json
+++ b/workato-platform-cli/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "workato-platform-cli",
   "description": "Workato Platform CLI for managing workspace recipes, connections, projects, and deployments",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }

--- a/workato-recipe/.claude-plugin/plugin.json
+++ b/workato-recipe/.claude-plugin/plugin.json
@@ -2,7 +2,6 @@
   "name": "workato-recipe",
   "description": "Parse and analyze Workato recipe JSON exports for logic, data flow, field mappings, error handling, and control flow",
   "author": {
-    "name": "Dave Kreitter",
-    "email": "dave@grailautomation.com"
+    "name": "Grail Automation"
   }
 }


### PR DESCRIPTION
## Summary
- remove real email addresses from Claude plugin manifests while preserving author attribution
- change Dave-authored public manifests to `Grail Automation`; keep `dev-browser` attributed to Sawyer Hood without an email
- tighten `scripts/validate_repo.rb` and repo docs so `plugin.json` is covered by email hygiene checks

## Validation
- `ruby scripts/validate_repo.rb`
- `ruby -c scripts/validate_repo.rb`
- `claude plugin validate .claude-plugin/marketplace.json`
- `git diff --check`
- repo-wide email scan for tracked Markdown/JSON excluding examples, repo docs, and marketplace metadata
