### PR TITLE
Expose staff plan review to Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -195,6 +195,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
+    },
+    {
+      "name": "staff-software-engineer",
+      "source": {
+        "source": "local",
+        "path": "./staff-software-engineer"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -37,6 +37,7 @@ The tracked Codex marketplace exposes:
 | `namecheap` | Migrated | Public MCP-backed registrar/DNS plugin; credentials and whitelisted IPs stay outside the repo; published `npx` MCP startup lists 8 tools. |
 | `context7` | Migrated | Public MCP-backed docs plugin; ships Context7 MCP config and current tool schema; published `npx` MCP startup lists `resolve-library-id` and `query-docs`. |
 | `codex-session-history` | Migrated | Codex-specific split from `jq-for-clawd`; uses `~/.codex/sessions` and `~/.codex/archived_sessions` JSONL shapes instead of Claude Code's project session layout. |
+| `staff-software-engineer` | Migrated | Claude agent behavior preserved; Codex exposure is a `staff-plan-review` skill rather than a Claude subagent definition. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -83,7 +84,7 @@ These should not be mechanically exposed by adding manifests only.
 
 | Plugin group | Required action before listing | Why it is blocked |
 | --- | --- | --- |
-| `agents`, `staff-software-engineer` | Rewrite useful agent prompts as Codex skills with `SKILL.md`; keep Claude-only agent files out of Codex manifests. | These plugins are agent-definition bundles, and Claude subagent metadata is not a Codex plugin interface. |
+| `agents` | Rewrite only useful agent prompts as Codex skills with `SKILL.md`; keep Claude-only agent files out of Codex manifests. | This plugin is an agent-definition bundle, and Claude subagent metadata is not a Codex plugin interface. |
 | `issue-blaster`, `scraper-generator` | Replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end issue/scraper flow. | Both plugins mix skills with Claude agents and assume delegation surfaces that Codex will not load as plugin skills. |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | For each domain pack, map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
 | `google-workspace` | Split the large recipe surface into safe read-only, write/send, and watch/automation groups; map each group to Codex Google connectors or MCP dependencies before listing. | The plugin has many action-oriented recipes with different auth and side-effect profiles, so one manifest policy is too coarse. |
@@ -105,7 +106,7 @@ These are working classifications, not final deletion decisions:
 | `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |
 | `dev-browser` | `parked` | Do not list for Codex until [issue #20](https://github.com/grailautomation/claude-plugins/issues/20) resolves the keep/retire/validate path. |
 | `playwright-cli` | `public-marketplace` Claude-only | Keep listed for Claude; do not list for Codex unless a concrete gap appears versus the installed Codex `playwright` skill. |
-| `agents`, `staff-software-engineer` | `parked` | Rewrite only the useful prompts as skills when there is a current use case. |
+| `agents` | `parked` | Rewrite only the useful prompts as skills when there is a current use case; generic explore/plan/bash agents overlap Codex's built-in delegation surfaces. |
 
 ## Migration Rules
 

--- a/staff-software-engineer/.codex-plugin/plugin.json
+++ b/staff-software-engineer/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "staff-software-engineer",
+  "version": "0.1.0",
+  "description": "Staff-level implementation plan review for architecture, correctness, risk, and test coverage.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/staff-software-engineer",
+  "keywords": [
+    "planning",
+    "architecture",
+    "review",
+    "staff-engineer",
+    "software-engineering"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Staff Software Engineer",
+    "shortDescription": "Review implementation plans",
+    "longDescription": "Use Staff Software Engineer to review implementation plans for architectural fit, correctness, risks, missing validation, and operational gaps before execution.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read"
+    ],
+    "defaultPrompt": [
+      "Review this implementation plan as a staff engineer",
+      "Use staff-plan-review before we proceed",
+      "Find the risks in this plan"
+    ],
+    "brandColor": "#1F2937",
+    "screenshots": []
+  }
+}

--- a/staff-software-engineer/skills/staff-plan-review/SKILL.md
+++ b/staff-software-engineer/skills/staff-plan-review/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: staff-plan-review
+description: Review implementation plans as a staff software engineer. Use when the user asks for staff engineer feedback, senior engineering review, plan review, architecture review, implementation-plan critique, approval before proceeding, risk review, or feedback on a proposed technical plan.
+---
+
+# Staff Plan Review
+
+Review the supplied implementation plan. Stay in review mode: do not implement the plan or rewrite it unless the user explicitly asks for replacement text.
+
+## Review Stance
+
+- Prioritize correctness, architecture, maintainability, migration safety, operational risk, and validation quality.
+- Ground feedback in the actual repo or provided plan. If the plan references files or behavior and the repo is available, inspect the relevant files before making strong claims.
+- Calibrate to a solo indie project: favor practical safeguards over enterprise ceremony.
+- Challenge vague ownership, missing rollback paths, unclear data migration behavior, test gaps, or assumptions that are not validated by evidence.
+- Prefer concrete fixes over generic advice.
+
+## Output Shape
+
+Start with one of these verdicts:
+
+- `Approved` — no blocking issues; only optional improvements.
+- `Approved With Notes` — plan is safe enough to proceed, but has non-blocking improvements.
+- `Needs Changes` — one or more issues should be fixed before implementation.
+
+Then provide the highest-signal sections needed:
+
+- `Blocking Issues`: correctness or risk problems that should stop implementation.
+- `Important Notes`: non-blocking gaps, tradeoffs, or validation improvements.
+- `Suggested Edits`: concise replacement bullets or plan changes when useful.
+- `Residual Risk`: what remains uncertain after the review.
+
+Keep the review concise. Do not invent concerns just to fill sections; omit empty sections.
+
+## Review Checklist
+
+Check whether the plan:
+
+- Names the actual files, modules, commands, and data surfaces involved.
+- Fits existing architecture and local conventions.
+- Separates cleanup, migration, and new feature work when that lowers risk.
+- Preserves user data, credentials, local state, and unrelated worktree changes.
+- Defines validation that matches the blast radius.
+- Has clear stop conditions for risky or irreversible actions.
+- Avoids depending on outdated docs, unstated environment assumptions, or unavailable tools.
+
+If the plan is underspecified, ask for the missing input only when it blocks a useful review. Otherwise state assumptions and proceed.

--- a/staff-software-engineer/skills/staff-plan-review/agents/openai.yaml
+++ b/staff-software-engineer/skills/staff-plan-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Staff Plan Review"
+  short_description: "Review implementation plans for risk"
+  brand_color: "#1F2937"
+  default_prompt: "Use $staff-plan-review to review this implementation plan before we proceed."


### PR DESCRIPTION
## Summary
- add a Codex manifest for `staff-software-engineer`
- preserve the Claude subagent, but expose Codex behavior as a `staff-plan-review` skill
- update the migration ledger so the generic `agents` bundle remains parked while this useful review workflow is migrated

## Validation
- `ruby scripts/validate_repo.rb`
- `jq empty .agents/plugins/marketplace.json staff-software-engineer/.codex-plugin/plugin.json staff-software-engineer/.claude-plugin/plugin.json`
- `git diff --check`
- `claude plugin validate staff-software-engineer` (passes with existing no-version warning)
