### PR TITLE
Track agents bundle extraction

### DIFF
--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -84,7 +84,7 @@ These should not be mechanically exposed by adding manifests only.
 
 | Plugin group | Required action before listing | Why it is blocked |
 | --- | --- | --- |
-| `agents` | Rewrite only useful agent prompts as Codex skills with `SKILL.md`; keep Claude-only agent files out of Codex manifests. | This plugin is an agent-definition bundle, and Claude subagent metadata is not a Codex plugin interface. |
+| `agents` | Resolve [issue #29](https://github.com/grailautomation/claude-plugins/issues/29): rewrite only useful agent prompts as Codex skills with `SKILL.md`; keep Claude-only agent files out of Codex manifests. | This plugin is an agent-definition bundle, and Claude subagent metadata is not a Codex plugin interface. |
 | `issue-blaster`, `scraper-generator` | Resolve [issue #23](https://github.com/grailautomation/claude-plugins/issues/23): replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end issue/scraper flow. | Both plugins mix skills with Claude agents and assume delegation surfaces that Codex will not load as plugin skills. |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Resolve [issue #25](https://github.com/grailautomation/claude-plugins/issues/25): map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
 | `google-workspace` | Resolve [issue #27](https://github.com/grailautomation/claude-plugins/issues/27): split the large recipe surface into safe read-only, write/send, watch/automation, admin/security, and multi-product recipe groups before listing. | The plugin has many action-oriented recipes with different auth and side-effect profiles, so one manifest policy is too coarse. |
@@ -106,7 +106,7 @@ These are working classifications, not final deletion decisions:
 | `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |
 | `dev-browser` | `parked` | Do not list for Codex until [issue #20](https://github.com/grailautomation/claude-plugins/issues/20) resolves the keep/retire/validate path. |
 | `playwright-cli` | `public-marketplace` Claude-only | Keep listed for Claude; do not list for Codex unless a concrete gap appears versus the installed Codex `playwright` skill. |
-| `agents` | `parked` | Rewrite only the useful prompts as skills when there is a current use case; generic explore/plan/bash agents overlap Codex's built-in delegation surfaces. |
+| `agents` | `parked` | Track extraction decisions in [issue #29](https://github.com/grailautomation/claude-plugins/issues/29); generic explore/plan/bash agents overlap Codex's built-in delegation surfaces. |
 
 ## Migration Rules
 


### PR DESCRIPTION
## Summary
- create and link issue #29 for deciding which Claude subagent prompts, if any, should become Codex skills
- keep the generic `agents` bundle parked instead of listing Claude subagent metadata for Codex

## Validation
- `ruby scripts/validate_repo.rb`
- `git diff --check`
