### PR TITLE
Record broad Google Workspace plugin decision

### DIFF
--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -87,7 +87,7 @@ These should not be mechanically exposed by adding manifests only.
 | `agents` | Resolve [issue #29](https://github.com/grailautomation/claude-plugins/issues/29): rewrite only useful agent prompts as Codex skills with `SKILL.md`; keep Claude-only agent files out of Codex manifests. | This plugin is an agent-definition bundle, and Claude subagent metadata is not a Codex plugin interface. |
 | `issue-blaster`, `scraper-generator` | Resolve [issue #23](https://github.com/grailautomation/claude-plugins/issues/23): replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end issue/scraper flow. | Both plugins mix skills with Claude agents and assume delegation surfaces that Codex will not load as plugin skills. |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Resolve [issue #25](https://github.com/grailautomation/claude-plugins/issues/25): map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
-| `google-workspace` | Resolve [issue #27](https://github.com/grailautomation/claude-plugins/issues/27): split the large recipe surface into safe read-only, write/send, watch/automation, admin/security, and multi-product recipe groups before listing. | The plugin has many action-oriented recipes with different auth and side-effect profiles, so one manifest policy is too coarse. |
+| `google-workspace` | Resolve [issue #27](https://github.com/grailautomation/claude-plugins/issues/27): validate the single broad Google Workspace plugin against existing MCP config, auth setup, and side-effect expectations before listing. | The plugin has many action-oriented recipes, but the accepted architecture is one broad plugin rather than side-effect-based plugin fragmentation. |
 | `dev-browser` | Resolve [issue #20](https://github.com/grailautomation/claude-plugins/issues/20): decide keep, retire, or narrow Codex adaptation; if kept for Codex, run its server/extension validation first. | It is a full browser-extension/runtime project, not a simple skill bundle, and it overlaps existing Codex browser capabilities. |
 
 ### Initial Residency Calls
@@ -100,8 +100,8 @@ These are working classifications, not final deletion decisions:
 | `terminal-tidbits` | `split-public-private` | Public skill stays here; personal notes stay outside the plugin directory. |
 | `salesforce-soql` | `split-public-private` | Public SOQL and CLI workflows stay here; org schemas remain ignored/local unless sanitized examples are deliberate. |
 | `cloudflare`, `namecheap` | `public-marketplace` | Keep in the public Claude marketplace. Credentials, account IDs, whitelisted IPs, and domain lists stay outside the repo in environment variables, account settings, Claude/Codex config, or gitignored local notes. |
-| Domain MCP packs | `needs-generalization` | Preserve Claude MCP parity first; track Codex connector/auth/side-effect mapping in [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). |
-| `google-workspace` | `needs-generalization` | Track the read/write/send/watch/admin split in [issue #27](https://github.com/grailautomation/claude-plugins/issues/27); preserve Claude behavior until each Codex group is reviewed. |
+| Domain MCP packs | `needs-generalization` | Preserve existing MCP behavior first; track Codex connector/auth/side-effect mapping in [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). |
+| `google-workspace` | `needs-generalization` | Keep as one broad plugin; track connector/auth validation and side-effect expectations in [issue #27](https://github.com/grailautomation/claude-plugins/issues/27). |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
 | `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |
 | `dev-browser` | `parked` | Do not list for Codex until [issue #20](https://github.com/grailautomation/claude-plugins/issues/20) resolves the keep/retire/validate path. |
@@ -113,8 +113,8 @@ These are working classifications, not final deletion decisions:
 - Add a plugin to `.agents/plugins/marketplace.json` only after its
   `.codex-plugin/plugin.json`, skill metadata, and runtime assumptions have been
   reviewed.
-- Preserve the existing Claude asset architecture by default. Do not replace an
-  MCP-backed Claude workflow with a native Codex app/connector unless there is a
+- Preserve the existing asset architecture by default. Do not replace an
+  MCP-backed workflow with a native Codex app/connector unless there is a
   documented reason; open a GitHub issue for those exceptions.
 - Prefer `skills/<skill>/agents/openai.yaml` for Codex-only invocation policy
   instead of overloading Claude-specific frontmatter.

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -1,7 +1,7 @@
 # MCP Inventory
 
 This inventory reflects the tracked `.mcp.json` files in this repository. It is
-not a Codex migration approval list. Preserve Claude MCP parity by default; if a
+not a Codex migration approval list. Preserve existing MCP behavior by default; if a
 native Codex app/connector looks materially better for a specific dependency,
 open a GitHub issue instead of silently substituting it.
 
@@ -12,45 +12,45 @@ Connector-heavy domain pack review is tracked in
 
 | Server | Kind | Current config | Used by | Env vars | Current disposition |
 | --- | --- | --- | --- | --- | --- |
-| `amplitude` | HTTP MCP | `https://mcp.amplitude.com/mcp` | `data`, `product-management` |  | Claude MCP parity review required |
-| `apollo` | HTTP MCP | `https://api.apollo.io/mcp` | `sales` |  | Claude MCP parity review required |
-| `asana` | HTTP MCP | `https://mcp.asana.com/v2/mcp` | `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity` |  | Claude MCP parity review required |
-| `atlassian` | HTTP MCP | `https://mcp.atlassian.com/v1/mcp` | `data`, `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
-| `bigquery` | HTTP MCP | `https://bigquery.googleapis.com/mcp` | `data`, `finance` |  | Claude MCP parity review required |
-| `clay` | HTTP MCP | `https://api.clay.com/v3/mcp` | `sales` |  | Claude MCP parity review required |
-| `clickup` | HTTP MCP | `https://mcp.clickup.com/mcp` | `product-management`, `productivity` |  | Claude MCP parity review required |
-| `close` | HTTP MCP | `https://mcp.close.com/mcp` | `sales` |  | Claude MCP parity review required |
+| `amplitude` | HTTP MCP | `https://mcp.amplitude.com/mcp` | `data`, `product-management` |  | Existing MCP behavior review required |
+| `apollo` | HTTP MCP | `https://api.apollo.io/mcp` | `sales` |  | Existing MCP behavior review required |
+| `asana` | HTTP MCP | `https://mcp.asana.com/v2/mcp` | `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity` |  | Existing MCP behavior review required |
+| `atlassian` | HTTP MCP | `https://mcp.atlassian.com/v1/mcp` | `data`, `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
+| `bigquery` | HTTP MCP | `https://bigquery.googleapis.com/mcp` | `data`, `finance` |  | Existing MCP behavior review required |
+| `clay` | HTTP MCP | `https://api.clay.com/v3/mcp` | `sales` |  | Existing MCP behavior review required |
+| `clickup` | HTTP MCP | `https://mcp.clickup.com/mcp` | `product-management`, `productivity` |  | Existing MCP behavior review required |
+| `close` | HTTP MCP | `https://mcp.close.com/mcp` | `sales` |  | Existing MCP behavior review required |
 | `cloudflare` | local npm MCP | `npx -y @grailautomation/cloudflare-mcp` | `cloudflare` | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` | Public Claude and Codex plugin; npm package exists at `0.1.0`; published `npx` tools/list smoke passed with 28 tools |
 | `context7` | local npm MCP | `npx -y @upstash/context7-mcp` | `context7` |  | Public Claude and Codex plugin; npm package latest observed at `2.2.5`; published `npx` tools/list smoke passed with 2 tools |
-| `datadog` | HTTP MCP | `https://mcp.datadoghq.com/mcp` | `engineering` |  | Claude MCP parity review required |
-| `docusign` | HTTP MCP | `https://mcp.docusign.com/mcp` | `legal` |  | Claude MCP parity review required |
-| `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Claude MCP parity review required |
-| `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Claude MCP parity review required |
-| `github` | HTTP MCP | `https://api.github.com/mcp` | `engineering` |  | Claude MCP parity review required |
-| `gmail` | HTTP MCP | `https://gmail.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
-| `google-calendar` | HTTP MCP | `https://gcal.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
-| `google-drive` | HTTP MCP | `https://google-drive-mcp.claude.com/mcp` | `legal` |  | Claude MCP parity review required |
-| `guru` | HTTP MCP | `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Claude MCP parity review required |
-| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Claude MCP parity review required |
-| `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Claude MCP parity review required |
-| `intercom` | HTTP MCP | `https://mcp.intercom.com/mcp` | `design`, `product-management` |  | Claude MCP parity review required |
-| `linear` | HTTP MCP | `https://mcp.linear.app/mcp` | `design`, `engineering`, `product-management`, `productivity` |  | Claude MCP parity review required |
-| `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Claude MCP parity review required |
-| `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Claude MCP parity review required |
+| `datadog` | HTTP MCP | `https://mcp.datadoghq.com/mcp` | `engineering` |  | Existing MCP behavior review required |
+| `docusign` | HTTP MCP | `https://mcp.docusign.com/mcp` | `legal` |  | Existing MCP behavior review required |
+| `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Existing MCP behavior review required |
+| `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Existing MCP behavior review required |
+| `github` | HTTP MCP | `https://api.github.com/mcp` | `engineering` |  | Existing MCP behavior review required |
+| `gmail` | HTTP MCP | `https://gmail.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
+| `google-calendar` | HTTP MCP | `https://gcal.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
+| `google-drive` | HTTP MCP | `https://google-drive-mcp.claude.com/mcp` | `legal` |  | Existing MCP behavior review required |
+| `guru` | HTTP MCP | `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Existing MCP behavior review required |
+| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Existing MCP behavior review required |
+| `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Existing MCP behavior review required |
+| `intercom` | HTTP MCP | `https://mcp.intercom.com/mcp` | `design`, `product-management` |  | Existing MCP behavior review required |
+| `linear` | HTTP MCP | `https://mcp.linear.app/mcp` | `design`, `engineering`, `product-management`, `productivity` |  | Existing MCP behavior review required |
+| `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Existing MCP behavior review required |
+| `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Existing MCP behavior review required |
 | `namecheap` | local npm MCP | `npx -y @grailautomation/namecheap-mcp` | `namecheap` | `NAMECHEAP_API_KEY`, `NAMECHEAP_API_USER`, `NAMECHEAP_USERNAME` | Public Claude and Codex plugin; npm package exists at `0.1.0`; published `npx` tools/list smoke passed with 8 tools |
-| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
-| `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Claude MCP parity review required |
-| `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Claude MCP parity review required |
-| `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Claude MCP parity review required |
-| `servicenow` | HTTP MCP | `https://mcp.servicenow.com/mcp` | `operations` |  | Claude MCP parity review required |
-| `similarweb` | HTTP MCP | `https://mcp.similarweb.com/mcp` | `product-management`, `sales` |  | Claude MCP parity review required |
-| `slack` | HTTP MCP | `https://mcp.slack.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Claude MCP parity review required |
-| `zoominfo` | HTTP MCP | `https://mcp.zoominfo.com/mcp` | `sales` |  | Claude MCP parity review required |
+| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
+| `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Existing MCP behavior review required |
+| `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Existing MCP behavior review required |
+| `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Existing MCP behavior review required |
+| `servicenow` | HTTP MCP | `https://mcp.servicenow.com/mcp` | `operations` |  | Existing MCP behavior review required |
+| `similarweb` | HTTP MCP | `https://mcp.similarweb.com/mcp` | `product-management`, `sales` |  | Existing MCP behavior review required |
+| `slack` | HTTP MCP | `https://mcp.slack.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
+| `zoominfo` | HTTP MCP | `https://mcp.zoominfo.com/mcp` | `sales` |  | Existing MCP behavior review required |
 
 ## Review Rules
 
 - Do not list connector-heavy plugins for Codex by adding manifests only.
-- Keep the current Claude MCP architecture as the default source of truth.
+- Keep the current MCP configuration as the default source of truth.
 - For HTTP MCP servers, verify Codex runtime support, auth setup, and side
   effects before listing the owning plugin.
 - For local npm MCP servers, verify package name, package manager/lockfile,


### PR DESCRIPTION
## Summary
- update the Google Workspace migration plan to keep one broad plugin instead of splitting by side-effect surface
- update issue #27 to track validation of the broad plugin rather than plugin fragmentation
- replace "Claude MCP parity" wording with "existing MCP behavior/configuration" in the MCP inventory and migration rules

## Validation
- `ruby scripts/validate_repo.rb`
- `git diff --check`
