### PR TITLE
Add Codex adapter for issue-blaster

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -207,6 +207,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "issue-blaster",
+      "source": {
+        "source": "local",
+        "path": "./issue-blaster"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -38,6 +38,7 @@ The tracked Codex marketplace exposes:
 | `context7` | Migrated | Public MCP-backed docs plugin; ships Context7 MCP config and current tool schema; published `npx` MCP startup lists `resolve-library-id` and `query-docs`. |
 | `codex-session-history` | Migrated | Codex-specific split from `jq-for-clawd`; uses `~/.codex/sessions` and `~/.codex/archived_sessions` JSONL shapes instead of Claude Code's project session layout. |
 | `staff-software-engineer` | Migrated | Claude agent behavior preserved; Codex exposure is a `staff-plan-review` skill rather than a Claude subagent definition. |
+| `issue-blaster` | Migrated | Claude slash-command and subagent behavior preserved; Codex exposure uses direct `gh`/`rg` workflows, sequential multi-issue handling by default, and explicit user-authorized subagents only for parallel work. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -90,7 +91,7 @@ These should not be mechanically exposed by adding manifests only.
 
 | Plugin group | Required action before listing | Why it is blocked |
 | --- | --- | --- |
-| `issue-blaster`, `scraper-generator` | Resolve [issue #23](https://github.com/grailautomation/claude-plugins/issues/23): replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end issue/scraper flow. | Both plugins mix skills with Claude agents and assume delegation surfaces that Codex will not load as plugin skills. |
+| `scraper-generator` | Resolve the remaining scraper-generator portion of [issue #23](https://github.com/grailautomation/claude-plugins/issues/23): replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end scraper flow. | The plugin mixes skills with Claude agents and assumes delegation surfaces that Codex will not load as plugin skills. |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Resolve [issue #25](https://github.com/grailautomation/claude-plugins/issues/25): map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
 | `google-workspace` | Resolve [issue #27](https://github.com/grailautomation/claude-plugins/issues/27): validate the single broad Google Workspace plugin against existing MCP config, auth setup, and side-effect expectations before listing. | The plugin has many action-oriented recipes, but the accepted architecture is one broad plugin rather than side-effect-based plugin fragmentation. |
 | `dev-browser` | Resolve [issue #20](https://github.com/grailautomation/claude-plugins/issues/20): decide keep, retire, or narrow Codex adaptation; if kept for Codex, run its server/extension validation first. | It is a full browser-extension/runtime project, not a simple skill bundle, and it overlaps existing Codex browser capabilities. |
@@ -105,6 +106,7 @@ These are working classifications, not final deletion decisions:
 | `terminal-tidbits` | `split-public-private` | Public skill stays here; personal notes stay outside the plugin directory. |
 | `salesforce-soql` | `split-public-private` | Public SOQL and CLI workflows stay here; org schemas remain ignored/local unless sanitized examples are deliberate. |
 | `cloudflare`, `namecheap` | `public-marketplace` | Keep in the public Claude marketplace. Credentials, account IDs, whitelisted IPs, and domain lists stay outside the repo in environment variables, account settings, Claude/Codex config, or gitignored local notes. |
+| `issue-blaster` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex uses direct single-issue `gh`/`rg` analysis and explicit user-authorized subagents only for parallelism. |
 | Domain MCP packs | `needs-generalization` | Preserve existing MCP behavior first; track Codex connector/auth/side-effect mapping in [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). |
 | `google-workspace` | `needs-generalization` | Keep as one broad plugin; track connector/auth validation and side-effect expectations in [issue #27](https://github.com/grailautomation/claude-plugins/issues/27). |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |

--- a/issue-blaster/.codex-plugin/plugin.json
+++ b/issue-blaster/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "issue-blaster",
+  "description": "Analyze GitHub issues, generate implementation plan options, and execute selected plans with explicit Codex workflows.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/issue-blaster",
+  "keywords": [
+    "github",
+    "issues",
+    "planning",
+    "implementation",
+    "worktrees"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Issue Blaster",
+    "shortDescription": "Plan and implement GitHub issues",
+    "longDescription": "Use Issue Blaster to inspect GitHub issues with gh, research the local codebase with rg, generate 2-4 implementation options, and implement a selected plan with explicit branch, worktree, commit, and PR handling.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use issue-blaster to analyze this GitHub issue",
+      "Generate implementation options for issue #123",
+      "Implement this issue-blaster plan"
+    ],
+    "brandColor": "#24292F",
+    "screenshots": []
+  }
+}

--- a/issue-blaster/README.md
+++ b/issue-blaster/README.md
@@ -1,16 +1,17 @@
 # Issue Blaster
 
-A Claude Code plugin for analyzing GitHub issues and implementing AI-generated solution plans.
+A Claude Code and Codex plugin for analyzing GitHub issues and implementing
+AI-generated solution plans.
 
 ## Features
 
 - **Solve**: Analyze GitHub issues and generate 2-4 solution plans
 - **Implement**: Execute solution plans via worktrees with automated branching, commits, and merge options
-- **Parallel Processing**: Solve and implement multiple issues concurrently using Task tool
+- **Parallel Processing**: Solve and implement multiple issues concurrently in Claude Code using the Task tool, or in Codex only when the user explicitly authorizes subagents
 
 ## Requirements
 
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) or Codex with this plugin enabled
 - [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated
 - [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) for code search
 
@@ -30,6 +31,12 @@ claude --plugin-dir /path/to/claude-plugins/issue-blaster
 ```
 
 Or install it from the configured Claude plugin marketplace.
+
+### Codex
+
+The repository marketplace lists this plugin through
+`.agents/plugins/marketplace.json`. Install it from the Grail Automation Codex
+marketplace in Codex after refreshing the local marketplace.
 
 ## Usage
 
@@ -63,6 +70,10 @@ Or install it from the configured Claude plugin marketplace.
 ```
 
 Each implementation creates a worktree in `.worktrees/`, makes the code changes, commits, and offers merge options (including "leave it" to defer merging).
+
+In Codex, implementation follows normal Codex repo workflow. Use worktrees only
+when they reduce risk or when explicitly requested, and do not merge or push
+without the user's intent.
 
 ## Output Structure
 

--- a/issue-blaster/skills/implement/SKILL.md
+++ b/issue-blaster/skills/implement/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: implement
-description: Implement one or more chosen solution plans
+description: "Issue Blaster implement command: implement a selected issue plan from plans/issue-* with explicit git, validation, commit, and PR handling."
 argument-hint: <issue:option> [<issue:option> ...] | <issue> <option>
 allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Task, AskUserQuestion
 disable-model-invocation: true
 ---
 
-Implement the specified solution plan(s).
+Implement the specified solution plan(s). In Claude Code this skill is normally
+invoked as `/issue-blaster:implement`. In Codex, implement directly from the
+selected plan using normal repo-editing, validation, commit, push, and PR
+workflow; do not rely on Claude `Task`, `TaskOutput`, or `AskUserQuestion`.
 
 ## Arguments
 $ARGUMENTS
@@ -36,6 +39,16 @@ Determine the invocation style:
 #### Single Plan
 Invoke the plan-implementer agent directly with the parsed arguments.
 
+In Codex:
+- Read the selected plan file and verify it matches the requested issue/option
+- Check `git status --short --branch` before editing
+- Use the current branch when that matches the user's request; create a new
+  `codex/` branch or explicit worktree when isolation is needed
+- Implement the plan with normal Codex file edits
+- Run focused validation that matches the changed files
+- Commit, push, open a PR, and merge only when the user has asked for those
+  actions
+
 #### Multiple Plans (Parallel)
 For EACH issue:option pair, use the Task tool with:
 - **subagent_type**: `"plan-implementer"`
@@ -44,6 +57,14 @@ For EACH issue:option pair, use the Task tool with:
 - **prompt**: `"{issue} {option}"`
 
 After spawning all tasks, wait for completion using TaskOutput.
+
+In Codex:
+- Do not implement multiple plans in parallel unless the user explicitly asks
+  for subagents or parallel agent work
+- If parallel work is authorized, use one disjoint branch/worktree per plan and
+  keep ownership boundaries explicit
+- If parallel work is not authorized, implement one selected plan or ask which
+  plan should go first
 
 ### Step 3: Report Results
 

--- a/issue-blaster/skills/issue-blaster/SKILL.md
+++ b/issue-blaster/skills/issue-blaster/SKILL.md
@@ -5,26 +5,28 @@ description: Workflow for analyzing GitHub issues, generating solution plans, an
 
 # issue-blaster Workflow
 
-A two-phase approach to solving GitHub issues with AI assistance.
+A two-phase approach to solving GitHub issues with AI assistance. This plugin
+supports Claude Code slash-command/subagent usage and Codex direct workflow
+usage.
 
 ## Quick Reference
 
-| Task | How | Agent |
-|------|-----|-------|
-| Generate plans (single) | `/issue-blaster:solve 123` | issue-blaster |
-| Generate plans (batch) | `/issue-blaster:solve 1 2 3` | issue-blaster (via Task) |
-| Execute plan (single) | `/issue-blaster:implement 123:1` | plan-implementer |
-| Execute plans (parallel) | `/issue-blaster:implement 123:1 456:2` | plan-implementer (via Task) |
-| Execute plan (direct) | `@issue-blaster:plan-implementer 123 1` | plan-implementer |
+| Task | Claude Code | Codex |
+|------|-------------|-------|
+| Generate plans (single) | `/issue-blaster:solve 123` | Inspect the issue with `gh`, research with `rg`, then write `plans/issue-{N}/option-*.md` |
+| Generate plans (batch) | `/issue-blaster:solve 1 2 3` | Process sequentially unless the user explicitly authorizes Codex subagents |
+| Execute plan (single) | `/issue-blaster:implement 123:1` | Read the selected plan, verify git state, implement in the current branch or an explicit worktree |
+| Execute plans (parallel) | `/issue-blaster:implement 123:1 456:2` | Only when the user explicitly authorizes parallel Codex agents with disjoint worktrees |
+| Execute plan (direct) | `@issue-blaster:plan-implementer 123 1` | Use normal Codex repo-editing, validation, commit, push, and PR workflow |
 
 ## Parallelism Approaches
 
 | Approach | How | Best For |
 |----------|-----|----------|
 | Single issue | Direct agent call or `/solve N` | Normal usage |
-| Batch solve | `/solve 1 2 3` | Many issues to analyze |
-| Batch implement | `/implement 123:1 456:2 789:1` | Many plans to execute |
-| Outer Claude | Spawn multiple agents | Progressive results, fault isolation |
+| Batch solve | `/solve 1 2 3` in Claude; sequential loop in Codex | Many issues to analyze |
+| Batch implement | `/implement 123:1 456:2 789:1` in Claude; explicit Codex subagents only | Many plans to execute |
+| Outer agent parallelism | Claude Task agents or user-authorized Codex subagents | Progressive results, fault isolation |
 
 See [multi-issue.md](references/multi-issue.md) for detailed guidance.
 
@@ -37,6 +39,11 @@ Analyzes an issue and generates 2-4 distinct solution approaches.
 **Output**: Plan files in `plans/issue-{N}/option-{n}-{slug}.md`
 
 **Parallel Solving**: When multiple issues are provided, they are solved concurrently using the Task tool.
+
+**Codex Solving**: For one issue, use `gh issue view` to fetch issue metadata,
+`rg` to inspect the codebase, and local file reads to ground the plans. For
+multiple issues, process them one at a time unless the user explicitly asks for
+Codex subagents or parallel agent work.
 
 Each plan includes:
 - Issue summary
@@ -53,6 +60,11 @@ The `plan-implementer` agent executes a chosen plan.
 The agent handles the full lifecycle: worktree creation, code changes, commit, merge options, and cleanup. You can defer merging by choosing "Leave it" to keep the worktree for later.
 
 **Parallel Implementing**: `/issue-blaster:implement 123:1 456:2` dispatches multiple plan-implementer agents concurrently, each in its own worktree.
+
+**Codex Implementing**: Implementation is explicit and inherits the current
+Codex permissions and sandbox. Prefer normal Codex branch/PR workflow for one
+selected plan. Use worktrees only when they reduce risk or the user asks for
+isolation. Do not merge, push, or delete worktrees without explicit user intent.
 
 **Prerequisites**:
 - Clean git working directory

--- a/issue-blaster/skills/issue-blaster/agents/openai.yaml
+++ b/issue-blaster/skills/issue-blaster/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Issue Blaster"
+  short_description: "Plan and implement GitHub issues"
+  brand_color: "#24292F"
+  default_prompt: "Use $issue-blaster to generate implementation options for this GitHub issue."

--- a/issue-blaster/skills/issue-blaster/references/multi-issue.md
+++ b/issue-blaster/skills/issue-blaster/references/multi-issue.md
@@ -7,14 +7,18 @@ description: Guide for analyzing multiple GitHub issues using parallel agents
 
 When analyzing multiple GitHub issues, choose the appropriate parallelism strategy.
 
+Claude Code can use plugin Task agents internally. Codex requires explicit user
+authorization before spawning subagents or parallel agent work, so Codex should
+default to sequential processing unless the user has asked for parallelism.
+
 ## Decision Matrix
 
 | Scenario | Approach | Why |
 |----------|----------|-----|
-| 2-5 issues, want progressive results | Parallel agents | See results as each completes |
-| 2-5 issues, want unified output | `/solve 1 2 3` | Single formatted summary |
-| 5+ issues | `/solve 1 2 3 ...` | Context efficiency |
-| Fault isolation needed | Parallel agents | One failure won't affect others |
+| 2-5 issues, want progressive results | Claude Task agents or user-authorized Codex subagents | See results as each completes |
+| 2-5 issues, want unified output | `/solve 1 2 3` in Claude; sequential Codex loop | Single formatted summary |
+| 5+ issues | `/solve 1 2 3 ...` in Claude; staged Codex batches | Context efficiency |
+| Fault isolation needed | Separate agents or separate branches/worktrees | One failure won't affect others |
 
 ## Approach 1: SDK-Level Parallelism (Batch Mode)
 
@@ -84,6 +88,8 @@ Outer Claude can combine results into a summary:
 
 - **Batch mode**: Reports per-issue status in summary table, continues on failures
 - **Parallel agents**: Each failure is isolated, can retry individually
+- **Codex sequential mode**: Finish or park one issue before moving to the next;
+  report partial progress with plan paths and unresolved blockers
 
 ## Output Location
 

--- a/issue-blaster/skills/solve/SKILL.md
+++ b/issue-blaster/skills/solve/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: solve
-description: Analyze GitHub issues and generate solution plans
+description: "Issue Blaster solve command: analyze GitHub issue numbers and generate 2-4 solution plans using gh, rg, and repo-local research."
 argument-hint: <issue-numbers> [--repo owner/repo]
 allowed-tools: Bash, Read, Write, Glob, Grep, Task
 disable-model-invocation: true
 ---
 
-Analyze the specified GitHub issue(s) and generate 2-4 solution plans.
+Analyze the specified GitHub issue(s) and generate 2-4 solution plans. In
+Claude Code this skill is normally invoked as `/issue-blaster:solve`. In Codex,
+use the same workflow directly from the user's prompt; do not rely on Claude
+`Task` or `TaskOutput` dispatch.
 
 ## Arguments
 $ARGUMENTS
@@ -40,6 +43,14 @@ If only one issue number is provided:
 - Use the issue-blaster agent directly to analyze the issue
 - The agent will create plans in `plans/issue-{N}/`
 
+In Codex:
+- Fetch issue details with `gh issue view {number} --repo {repo} --json number,title,body,comments,labels,assignees,url`
+- Research the local codebase with `rg`, `git grep`, and targeted file reads
+- Create `plans/issue-{N}/`
+- Ensure `plans/` is ignored if writing plan files in the current repo
+- Write 2-4 plan files using the format in `references/plan-format.md`
+- Report the recommended option and plan file locations
+
 #### Multiple Issues (Parallel)
 If multiple issue numbers are provided, spawn parallel Task agents:
 
@@ -50,6 +61,13 @@ For EACH issue number, use the Task tool with:
 - **prompt**: `"Analyze GitHub issue {repo}#{number}. The repository is {repo}."`
 
 After spawning all tasks, wait for completion using TaskOutput.
+
+In Codex:
+- Process multiple issues sequentially by default
+- Use Codex subagents only when the user explicitly asks for parallel agent work
+- If subagents are authorized, assign one issue per subagent and keep write
+  ownership disjoint by issue plan directory
+- Aggregate each issue's JSON summary after all work completes
 
 ### Step 5: Report Results
 


### PR DESCRIPTION
## Summary
- add Codex plugin metadata and marketplace listing for `issue-blaster`
- preserve Claude slash-command/subagent behavior while documenting Codex direct `gh`/`rg` workflows
- make multi-issue and multi-plan parallelism explicit: Codex defaults to sequential work unless the user authorizes subagents
- update the migration ledger so issue #23 now tracks only the remaining `scraper-generator` rewrite

Progresses #23

## Validation
- refreshed official OpenAI Codex plugin docs for manifest and marketplace structure
- `ruby scripts/validate_repo.rb`
- `git diff --check HEAD~1 HEAD`
- `claude plugin validate issue-blaster` (passes with the expected no-version warning)
- smoke-tested the Codex single-issue path against issue #20 using `gh`, `rg`, and ignored plan files under `.scratch/issue-blaster-smoke/`
