### PR TITLE
Add Codex adapter for scraper-generator

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -219,6 +219,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "scraper-generator",
+      "source": {
+        "source": "local",
+        "path": "./scraper-generator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -39,6 +39,7 @@ The tracked Codex marketplace exposes:
 | `codex-session-history` | Migrated | Codex-specific split from `jq-for-clawd`; uses `~/.codex/sessions` and `~/.codex/archived_sessions` JSONL shapes instead of Claude Code's project session layout. |
 | `staff-software-engineer` | Migrated | Claude agent behavior preserved; Codex exposure is a `staff-plan-review` skill rather than a Claude subagent definition. |
 | `issue-blaster` | Migrated | Claude slash-command and subagent behavior preserved; Codex exposure uses direct `gh`/`rg` workflows, sequential multi-issue handling by default, and explicit user-authorized subagents only for parallel work. |
+| `scraper-generator` | Migrated | Claude slash-command and subagent behavior preserved; Codex exposure runs the analysis, architecture, code-generation, and validation phases inline with local fetch/file/shell tools unless the user explicitly authorizes Codex subagents. |
 
 The parked prototype files from the exploratory pass live under
 `.scratch/codex-adapter-prototype/2026-05-14/`. They are intentionally ignored
@@ -91,7 +92,6 @@ These should not be mechanically exposed by adding manifests only.
 
 | Plugin group | Required action before listing | Why it is blocked |
 | --- | --- | --- |
-| `scraper-generator` | Resolve the remaining scraper-generator portion of [issue #23](https://github.com/grailautomation/claude-plugins/issues/23): replace Claude subagent orchestration with Codex-native skill workflows, then smoke-test one end-to-end scraper flow. | The plugin mixes skills with Claude agents and assumes delegation surfaces that Codex will not load as plugin skills. |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Resolve [issue #25](https://github.com/grailautomation/claude-plugins/issues/25): map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
 | `google-workspace` | Resolve [issue #27](https://github.com/grailautomation/claude-plugins/issues/27): validate the single broad Google Workspace plugin against existing MCP config, auth setup, and side-effect expectations before listing. | The plugin has many action-oriented recipes, but the accepted architecture is one broad plugin rather than side-effect-based plugin fragmentation. |
 | `dev-browser` | Resolve [issue #20](https://github.com/grailautomation/claude-plugins/issues/20): decide keep, retire, or narrow Codex adaptation; if kept for Codex, run its server/extension validation first. | It is a full browser-extension/runtime project, not a simple skill bundle, and it overlaps existing Codex browser capabilities. |
@@ -107,6 +107,7 @@ These are working classifications, not final deletion decisions:
 | `salesforce-soql` | `split-public-private` | Public SOQL and CLI workflows stay here; org schemas remain ignored/local unless sanitized examples are deliberate. |
 | `cloudflare`, `namecheap` | `public-marketplace` | Keep in the public Claude marketplace. Credentials, account IDs, whitelisted IPs, and domain lists stay outside the repo in environment variables, account settings, Claude/Codex config, or gitignored local notes. |
 | `issue-blaster` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex uses direct single-issue `gh`/`rg` analysis and explicit user-authorized subagents only for parallelism. |
+| `scraper-generator` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex runs phases inline by default and validates generated scrapers with the bundled script. |
 | Domain MCP packs | `needs-generalization` | Preserve existing MCP behavior first; track Codex connector/auth/side-effect mapping in [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). |
 | `google-workspace` | `needs-generalization` | Keep as one broad plugin; track connector/auth validation and side-effect expectations in [issue #27](https://github.com/grailautomation/claude-plugins/issues/27). |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |

--- a/scraper-generator/.codex-plugin/plugin.json
+++ b/scraper-generator/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "scraper-generator",
+  "description": "Generate API documentation scraper packages through discovery, architecture planning, Python code generation, and validation.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/scraper-generator",
+  "keywords": [
+    "scraping",
+    "api-docs",
+    "documentation",
+    "code-generation",
+    "python"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Scraper Generator",
+    "shortDescription": "Generate API documentation scrapers",
+    "longDescription": "Use Scraper Generator to analyze API documentation pages, design a parser architecture, generate a Python scraper package, and validate the generated scraper with bundled checks.",
+    "developerName": "Grail Automation",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use scraper-generator to create a scraper for this API documentation page",
+      "Analyze this docs URL and generate a Python scraper",
+      "Validate this generated API docs scraper"
+    ],
+    "brandColor": "#0F766E",
+    "screenshots": []
+  }
+}

--- a/scraper-generator/README.md
+++ b/scraper-generator/README.md
@@ -1,10 +1,11 @@
 # Scraper Generator
 
-A Claude Code plugin that automates the creation of API documentation scrapers.
+A Claude Code and Codex plugin that automates the creation of API
+documentation scrapers.
 
 ## What It Does
 
-Given an API documentation URL, this plugin guides Claude through:
+Given an API documentation URL, this plugin guides Claude Code or Codex through:
 
 1. **Analyzing** the documentation site structure and patterns
 2. **Designing** a scraper architecture tailored to that structure
@@ -15,11 +16,20 @@ The result is a standalone scraper that runs forever without AI assistance.
 
 ## Usage
 
+### Claude Code
+
 ```
 /scraper-generator:create-scraper https://docs.example.com/api/users.html
 ```
 
 This generates a complete Python scraper package using the patterns documented in the bundled scraper architecture references.
+
+### Codex
+
+Install the plugin from the repo-local Grail Automation Codex marketplace, then
+ask Codex to use `create-scraper` with a documentation URL and output
+directory. Codex runs the same phases inline with local shell/file tools instead
+of Claude `Task` subagents.
 
 ## Components
 
@@ -32,6 +42,9 @@ This generates a complete Python scraper package using the patterns documented i
 | `code-generation` | How to write Python scraper code |
 
 ### Agents
+
+Claude Code can use these subagents. Codex uses the skills and references
+directly unless the user explicitly authorizes Codex subagents.
 
 | Agent | Role |
 |-------|------|
@@ -67,6 +80,9 @@ Add this plugin via the Claude Code marketplace or install directly:
 ```bash
 claude plugin install scraper-generator@grail-automation
 ```
+
+For Codex, the repository marketplace exposes this plugin through
+`.agents/plugins/marketplace.json`.
 
 ## License
 

--- a/scraper-generator/skills/code-generation/scripts/validate-scraper.sh
+++ b/scraper-generator/skills/code-generation/scripts/validate-scraper.sh
@@ -6,6 +6,7 @@
 # Example: validate-scraper.sh ./workato_scraper connections
 
 set -euo pipefail
+shopt -s nullglob globstar
 
 SCRAPER_DIR="${1:?Usage: validate-scraper.sh <scraper_dir> [section]}"
 SECTION="${2:-}"
@@ -72,7 +73,7 @@ echo ""
 echo "Checking Python syntax..."
 
 syntax_ok=true
-for pyfile in "$SCRAPER_DIR"/*.py "$SCRAPER_DIR"/**/*.py 2>/dev/null; do
+for pyfile in "$SCRAPER_DIR"/**/*.py; do
     if [[ -f "$pyfile" ]]; then
         if python3 -m py_compile "$pyfile" 2>/dev/null; then
             success "$(basename "$pyfile") syntax OK"

--- a/scraper-generator/skills/create-scraper/SKILL.md
+++ b/scraper-generator/skills/create-scraper/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: create-scraper
-description: Generate a complete API documentation scraper from a URL
+description: Generate a complete API documentation scraper from a URL. Use for API docs scraper generation, docs site analysis, parser architecture, Python scraper package creation, and validation.
 argument-hint: "<url> [--output <dir>]"
 disable-model-invocation: true
 ---
 
 # Create Scraper
 
-Generate a complete, production-ready API documentation scraper.
+Generate a complete, production-ready API documentation scraper. This workflow
+supports Claude Code slash-command/subagent usage and Codex direct workflow
+usage.
 
 ## What This Command Does
 
@@ -25,7 +27,13 @@ The result is a standalone scraper like `workato_scraper/` that can run forever 
 Resolve the plugin root before loading bundled references:
 
 - In Claude Code, use `${CLAUDE_PLUGIN_ROOT}`.
-- In other runtimes, use the `scraper-generator` plugin directory in the current repository or installed plugin location.
+- In Codex from this repository, use `<repo-root>/scraper-generator`.
+- In Codex from an installed plugin skill, resolve the plugin root as the
+  directory two levels above this `SKILL.md`.
+
+Codex does not load Claude plugin subagents or `Task` dispatch from this plugin.
+Run the phases inline unless the user explicitly asks for Codex subagents or
+parallel agent work.
 
 ### Phase 1: Site Analysis
 
@@ -34,10 +42,16 @@ First, understand the target documentation structure.
 **Load the doc-site-analysis skill:**
 Read `${PLUGIN_ROOT}/skills/doc-site-analysis/SKILL.md`
 
-**Fetch and analyze the target URL:**
+**Fetch and analyze the target URL in Claude Code:**
 ```
 WebFetch {url}
 ```
+
+**Fetch and analyze the target URL in Codex:**
+Use an available repo-safe fetch method, such as `curl -L`, `python3` with
+`urllib.request`, or Playwright only when static HTML is insufficient. Save a
+small HTML sample under the chosen output directory when it helps make the
+analysis repeatable.
 
 Identify:
 - Documentation framework (VuePress, Docusaurus, etc.)
@@ -49,11 +63,16 @@ Identify:
 **Document findings:**
 Write analysis to `{output}/site-analysis.md`
 
-Use the site-analyzer agent if the analysis is complex:
+Use the site-analyzer agent in Claude Code if the analysis is complex:
 ```
 Task: Analyze the API documentation structure at {url}
 Agent: site-analyzer
 ```
+
+In Codex, perform this analysis inline by reading
+`${PLUGIN_ROOT}/skills/doc-site-analysis/SKILL.md` and its targeted references.
+Spawn a Codex subagent only when the user explicitly authorizes parallel agent
+work.
 
 ### Phase 2: Architecture Design
 
@@ -91,11 +110,15 @@ Read `${PLUGIN_ROOT}/skills/code-generation/SKILL.md`
 9. `pyproject.toml` - Package configuration
 10. `README.md` - Usage documentation
 
-Use the code-generator agent for complex implementations:
+Use the code-generator agent in Claude Code for complex implementations:
 ```
 Task: Generate scraper code based on site-analysis.md
 Agent: code-generator
 ```
+
+In Codex, generate the package inline using
+`${PLUGIN_ROOT}/skills/code-generation/SKILL.md` and the architecture
+references. Keep generated files inside the requested output directory.
 
 ### Phase 4: Validation
 
@@ -106,11 +129,16 @@ Verify the generated scraper works.
 ${PLUGIN_ROOT}/skills/code-generation/scripts/validate-scraper.sh {output}/{name}_scraper
 ```
 
-Or use the validator agent:
+Or use the validator agent in Claude Code:
 ```
 Task: Validate the generated scraper at {output}/{name}_scraper
 Agent: scraper-validator
 ```
+
+In Codex, run the validation script directly from the resolved plugin root. If
+the generated scraper has dependencies that are not installed, create an
+isolated virtual environment inside the output directory or clearly report the
+missing dependency as a validation blocker.
 
 **Check:**
 - Package imports without errors

--- a/scraper-generator/skills/create-scraper/agents/openai.yaml
+++ b/scraper-generator/skills/create-scraper/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Create Scraper"
+  short_description: "Generate API docs scraper packages"
+  brand_color: "#0F766E"
+  default_prompt: "Use $create-scraper to generate a Python scraper for this API documentation URL."


### PR DESCRIPTION
## Summary
- add Codex plugin metadata and marketplace listing for `scraper-generator`
- preserve Claude slash-command/subagent behavior while documenting inline Codex analysis, architecture, code-generation, and validation phases
- fix the bundled scraper validator shell glob so generated scraper validation can run
- update the migration ledger to mark `scraper-generator` migrated

Resolves #23

## Validation
- refreshed official OpenAI Codex plugin docs for manifest and marketplace structure
- `ruby scripts/validate_repo.rb`
- `git diff --check HEAD~1 HEAD`
- `claude plugin validate scraper-generator` (passes with the expected no-version warning)
- `bash -n scraper-generator/skills/code-generation/scripts/validate-scraper.sh`
- smoke-tested a localhost docs URL through analysis, generated scraper package validation, runtime scrape, and JSON output validation under `.scratch/scraper-generator-smoke/`
