### PR TITLE
List Google Workspace for Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -89,6 +89,18 @@
       "category": "Integrations"
     },
     {
+      "name": "google-workspace",
+      "source": {
+        "source": "local",
+        "path": "./google-workspace"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
       "name": "oasb-scaffold",
       "source": {
         "source": "local",

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -79,6 +79,7 @@ scope decisions rather than mechanical manifest work.
 | --- | --- | --- |
 | `playwright-cli` | Covered | A user-level Codex `playwright` skill already exists; migrate only if this repo plugin has distinct value. |
 | `cloudflare` | Migrated | This repo's MCP-backed Cloudflare plugin is now exposed directly instead of substituting the native Codex Cloudflare deployment surface. |
+| `google-workspace` | Migrated | The broad plugin is now listed for Codex as a CLI-backed integration. It has no `.mcp.json`; use `gws` v0.22.5 or newer on `$PATH`, preserve the existing auth model, and keep side-effect confirmation rules in the plugin README and shared skill. |
 
 ### Resolved Non-Candidates
 
@@ -94,7 +95,6 @@ These should not be mechanically exposed by adding manifests only.
 | Plugin group | Required action before listing | Why it is blocked |
 | --- | --- | --- |
 | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Resolve [issue #25](https://github.com/grailautomation/claude-plugins/issues/25): map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
-| `google-workspace` | Resolve [issue #27](https://github.com/grailautomation/claude-plugins/issues/27): validate the single broad Google Workspace plugin against existing MCP config, auth setup, and side-effect expectations before listing. | The plugin has many action-oriented recipes, but the accepted architecture is one broad plugin rather than side-effect-based plugin fragmentation. |
 
 ### Initial Residency Calls
 
@@ -109,7 +109,7 @@ These are working classifications, not final deletion decisions:
 | `issue-blaster` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex uses direct single-issue `gh`/`rg` analysis and explicit user-authorized subagents only for parallelism. |
 | `scraper-generator` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex runs phases inline by default and validates generated scrapers with the bundled script. |
 | Domain MCP packs | `needs-generalization` | Preserve existing MCP behavior first; track Codex connector/auth/side-effect mapping in [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). |
-| `google-workspace` | `needs-generalization` | Keep as one broad plugin; track connector/auth validation and side-effect expectations in [issue #27](https://github.com/grailautomation/claude-plugins/issues/27). |
+| `google-workspace` | `public-marketplace` | Keep as one broad plugin for Claude and Codex. The integration is CLI-backed rather than MCP-backed; require current `gws` auth and side-effect confirmation instead of splitting by product or action class. |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
 | `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |
 | `dev-browser` | `public-marketplace` Claude-only | Keep listed for Claude. Do not list for Codex unless a future issue validates dependency-manager policy, server startup, extension scope, tests/typecheck, and browser-profile side-effect expectations against a concrete Codex use case. |

--- a/google-workspace/.codex-plugin/plugin.json
+++ b/google-workspace/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "google-workspace",
+  "version": "0.1.0",
+  "description": "Use the Google Workspace CLI for Gmail, Drive, Calendar, Sheets, Docs, Slides, Chat, Meet, Tasks, Forms, Keep, Events, Model Armor, and cross-service workflows.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/google-workspace",
+  "keywords": [
+    "google-workspace",
+    "gmail",
+    "drive",
+    "calendar",
+    "sheets",
+    "docs",
+    "cli"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Google Workspace",
+    "shortDescription": "Operate Google Workspace through gws",
+    "longDescription": "Use Google Workspace to inspect and operate Gmail, Drive, Calendar, Sheets, Docs, Slides, Chat, Meet, Tasks, Forms, Keep, Events, Model Armor, and cross-product workflows through the gws CLI. The plugin preserves the existing CLI integration model and requires a current gws binary plus normal Google authentication.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use Google Workspace to triage my unread Gmail",
+      "Use Google Workspace to upload this file to Drive",
+      "Use Google Workspace to find time on my calendar"
+    ],
+    "brandColor": "#4285F4",
+    "screenshots": []
+  }
+}

--- a/google-workspace/README.md
+++ b/google-workspace/README.md
@@ -1,0 +1,49 @@
+# Google Workspace Plugin
+
+Google Workspace is one broad plugin for the `gws` CLI. It is intentionally not
+split by product or side-effect class: Gmail, Drive, Calendar, Sheets, Docs,
+Slides, Chat, Meet, Tasks, Forms, Keep, Events, Model Armor, personas, and
+cross-product recipes live together because they share one CLI and one auth
+model.
+
+## Runtime Contract
+
+- The `gws` binary must be on `$PATH`.
+- Use `gws` v0.22.5 or newer. Older versions are missing helper commands used by
+  these skills, including Gmail reply, reply-all, forward, attachments, drafts,
+  and Calendar timezone support.
+- Verify the installed version with `gws --version` before relying on helper
+  commands.
+- This plugin does not ship an MCP server or `.mcp.json`; it preserves the
+  existing CLI-backed behavior for Claude Code and Codex.
+
+## Auth Contract
+
+- Check auth with `gws auth status` before running commands that call Google APIs.
+- Use `gws auth login` for interactive OAuth.
+- Use `gws auth login --readonly` when read-only access is enough.
+- Use `gws auth login --full` when Workspace Events, Pub/Sub, cloud-platform, or
+  Model Armor workflows are needed.
+- Service-account credentials can be supplied with
+  `GOOGLE_APPLICATION_CREDENTIALS` when the target API and domain policy support
+  that mode.
+
+## Side-Effect Classes
+
+- Read: agenda, Gmail triage, Drive/Sheets/Docs reads, reports, and schema
+  inspection.
+- Write: docs writes, sheet appends, Drive uploads, Calendar inserts, Tasks,
+  Forms, Keep, and Classroom changes.
+- Send/share/invite: Gmail sends/replies/forwards, Chat sends, Drive permission
+  changes, event attendee updates, and recipe workflows that notify people.
+- Watch/subscribe/renew: Gmail watches, Drive watches, Workspace Events, Pub/Sub
+  resources, and renewal helpers. Some resources persist unless `--cleanup` is
+  used.
+- Admin/security: Admin Reports, directory/admin APIs where present, and Model
+  Armor template operations.
+- Multi-product recipes: treat the whole recipe as the highest-impact class among
+  its steps.
+
+For write, delete, send, share, invite, watch, subscribe, renew, admin, security,
+or multi-product workflows, confirm intent with the user before executing. Prefer
+`--dry-run` where the helper supports it.

--- a/google-workspace/skills/gws-shared/SKILL.md
+++ b/google-workspace/skills/gws-shared/SKILL.md
@@ -11,6 +11,12 @@ user-invocable: false
 ## Installation
 
 The `gws` binary must be on `$PATH`. See the project README for install options.
+Use `gws` v0.22.5 or newer; older versions are missing helper commands and flags
+documented by this plugin.
+
+```bash
+gws --version
+```
 
 ## Authentication
 
@@ -51,6 +57,7 @@ gws <service> <resource> [sub-resource] <method> [flags]
 ## Security Rules
 
 - **Never** output secrets (API keys, tokens) directly
+- **Verify auth first** with `gws auth status` before commands that call Google APIs
 - **Always** confirm with user before executing write/delete commands
 - Prefer `--dry-run` for destructive operations
 - Use `--sanitize` for PII/content safety screening


### PR DESCRIPTION
## Summary
- Add a Codex plugin manifest and marketplace entry for the broad Google Workspace plugin.
- Document that this is CLI-backed rather than MCP-backed, with `gws` v0.22.5+ required on PATH.
- Record auth and side-effect expectations for read, write, send/share/invite, watch/subscribe/renew, admin/security, and multi-product workflows.

Resolves #27

## Validation
- ruby scripts/validate_repo.rb
- jq empty .agents/plugins/marketplace.json google-workspace/.codex-plugin/plugin.json google-workspace/.claude-plugin/plugin.json
- claude plugin validate google-workspace (passes with existing warning: missing Claude manifest version)
- git diff --check
- gws 0.22.5 help checks for Gmail forward/reply/reply-all/send, Calendar agenda, and Workspace Events subscribe via pnpm dlx
- gws 0.22.5 dry-runs for Gmail send, Drive upload, Calendar insert, and Workspace Events subscribe

## Notes
- The machine global `gws` is currently 0.6.0 under ~/Library/pnpm and is too old for several helper skills; this PR documents the required current CLI instead of downgrading the skills.
- Auth-dependent live/API checks require reauth before execution; I did not run mutating Google API calls.