### PR TITLE
Map domain MCP packs for Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -101,6 +101,126 @@
       "category": "Integrations"
     },
     {
+      "name": "data",
+      "source": {
+        "source": "local",
+        "path": "./data"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "design",
+      "source": {
+        "source": "local",
+        "path": "./design"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "engineering",
+      "source": {
+        "source": "local",
+        "path": "./engineering"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "enterprise-search",
+      "source": {
+        "source": "local",
+        "path": "./enterprise-search"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "finance",
+      "source": {
+        "source": "local",
+        "path": "./finance"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "legal",
+      "source": {
+        "source": "local",
+        "path": "./legal"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "operations",
+      "source": {
+        "source": "local",
+        "path": "./operations"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "product-management",
+      "source": {
+        "source": "local",
+        "path": "./product-management"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
+      "name": "productivity",
+      "source": {
+        "source": "local",
+        "path": "./productivity"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "sales",
+      "source": {
+        "source": "local",
+        "path": "./sales"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Integrations"
+    },
+    {
       "name": "oasb-scaffold",
       "source": {
         "source": "local",

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -80,6 +80,7 @@ scope decisions rather than mechanical manifest work.
 | `playwright-cli` | Covered | A user-level Codex `playwright` skill already exists; migrate only if this repo plugin has distinct value. |
 | `cloudflare` | Migrated | This repo's MCP-backed Cloudflare plugin is now exposed directly instead of substituting the native Codex Cloudflare deployment surface. |
 | `google-workspace` | Migrated | The broad plugin is now listed for Codex as a CLI-backed integration. It has no `.mcp.json`; use `gws` v0.22.5 or newer on `$PATH`, preserve the existing auth model, and keep side-effect confirmation rules in the plugin README and shared skill. |
+| Domain MCP packs | Migrated with filtered MCP configs | `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, and `sales` are listed for Codex with `.mcp.codex.json` files that preserve reachable hosted HTTP MCP endpoints and explicitly omit endpoints that failed MCP probes. See [DOMAIN_PACKS_CODEX.md](DOMAIN_PACKS_CODEX.md). |
 
 ### Resolved Non-Candidates
 
@@ -90,11 +91,9 @@ scope decisions rather than mechanical manifest work.
 
 ### Requires Rewrite Or Connector Review
 
-These should not be mechanically exposed by adding manifests only.
-
-| Plugin group | Required action before listing | Why it is blocked |
-| --- | --- | --- |
-| `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` | Resolve [issue #25](https://github.com/grailautomation/claude-plugins/issues/25): map every `.mcp.json` server to either a supported Codex MCP dependency, a Codex app/connector, or an intentional omission; then set explicit auth policy. | They are mostly connector catalogs. Listing them without auth/install mapping would expose broken or misleading integrations. |
+This bucket is currently empty. New connector-heavy candidates should not be
+mechanically exposed by adding manifests only; first map MCP dependencies,
+auth/setup expectations, and side-effect classes.
 
 ### Initial Residency Calls
 
@@ -108,7 +107,7 @@ These are working classifications, not final deletion decisions:
 | `cloudflare`, `namecheap` | `public-marketplace` | Keep in the public Claude marketplace. Credentials, account IDs, whitelisted IPs, and domain lists stay outside the repo in environment variables, account settings, Claude/Codex config, or gitignored local notes. |
 | `issue-blaster` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex uses direct single-issue `gh`/`rg` analysis and explicit user-authorized subagents only for parallelism. |
 | `scraper-generator` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex runs phases inline by default and validates generated scrapers with the bundled script. |
-| Domain MCP packs | `needs-generalization` | Preserve existing MCP behavior first; track Codex connector/auth/side-effect mapping in [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). |
+| Domain MCP packs | `public-marketplace` with filtered Codex MCP configs | Keep listed for Claude with the original `.mcp.json`. Codex uses `.mcp.codex.json` per pack, preserving reachable hosted HTTP MCP dependencies and omitting endpoints that failed MCP probes instead of substituting native connectors. |
 | `google-workspace` | `public-marketplace` | Keep as one broad plugin for Claude and Codex. The integration is CLI-backed rather than MCP-backed; require current `gws` auth and side-effect confirmation instead of splitting by product or action class. |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
 | `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |

--- a/DOMAIN_PACKS_CODEX.md
+++ b/DOMAIN_PACKS_CODEX.md
@@ -1,0 +1,64 @@
+# Domain Packs Codex Mapping
+
+This document records the Codex mapping for the connector-heavy domain packs:
+`data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`,
+`operations`, `product-management`, `productivity`, and `sales`.
+
+The Claude marketplace behavior is preserved. Each pack keeps its original
+`.mcp.json`. Codex uses `.mcp.codex.json`, which includes only hosted HTTP MCP
+endpoints that responded to a non-auth MCP `initialize` probe with either a
+valid initialize response or an auth/RBAC challenge.
+
+## Mapping Rules
+
+- Do not replace a hosted MCP dependency with a native Codex app or connector in
+  these packs unless a specific issue documents the exception.
+- Auth is install/runtime user setup. Most included endpoints returned an OAuth,
+  bearer-token, API-key, or RBAC challenge during unauthenticated probing.
+- Endpoints that returned `404`, failed DNS resolution, or otherwise did not
+  behave like reachable MCP servers are omitted from `.mcp.codex.json`.
+- Omitted endpoints stay in the Claude `.mcp.json` until a separate issue decides
+  whether to fix, replace, or remove them.
+- Side-effect boundaries stay workflow-level, not plugin boundaries. Commands
+  that write, send, share, invite, watch, subscribe, renew, administer, or change
+  external state require user confirmation before execution.
+
+## Pack Decisions
+
+| Pack | Codex MCP config | Included for Codex | Omitted from Codex |
+| --- | --- | --- | --- |
+| `data` | `.mcp.codex.json` | `bigquery`, `hex`, `amplitude`, `atlassian` | None |
+| `design` | `.mcp.codex.json` | `slack`, `figma`, `linear`, `asana`, `atlassian`, `notion`, `intercom` | `google-calendar`, `gmail` |
+| `engineering` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `atlassian`, `notion`, `pagerduty` | `github`, `datadog`, `google-calendar`, `gmail` |
+| `enterprise-search` | `.mcp.codex.json` | `slack`, `notion`, `guru`, `atlassian`, `asana`, `ms365` | `google-calendar`, `gmail` |
+| `finance` | `.mcp.codex.json` | `bigquery`, `slack`, `ms365` | `google-calendar`, `gmail` |
+| `legal` | `.mcp.codex.json` | `slack`, `docusign`, `hubspot`, `notion` | `google-calendar`, `gmail`, `google-drive` |
+| `operations` | `.mcp.codex.json` | `slack`, `notion`, `atlassian`, `asana`, `ms365` | `google-calendar`, `gmail`, `servicenow` |
+| `product-management` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `monday`, `clickup`, `atlassian`, `notion`, `figma`, `amplitude`, `intercom`, `fireflies`, `similarweb` | `pendo`, `google-calendar`, `gmail` |
+| `productivity` | `.mcp.codex.json` | `slack`, `notion`, `asana`, `linear`, `atlassian`, `ms365`, `monday`, `clickup` | `google-calendar`, `gmail` |
+| `sales` | `.mcp.codex.json` | `slack`, `hubspot`, `close`, `clay`, `zoominfo`, `notion`, `atlassian`, `fireflies`, `ms365`, `similarweb` | `apollo`, `outreach`, `google-calendar`, `gmail` |
+
+## Side-Effect Expectations
+
+| Class | Examples | Runtime expectation |
+| --- | --- | --- |
+| Read-only | Search, analysis, dashboard review, design critique, CRM lookup, knowledge synthesis | May run after auth is available; cite sources and avoid exporting sensitive data unnecessarily. |
+| Write/send/share/invite | Slack or Chat posts, Gmail or Microsoft 365 sends, Drive or DocuSign sharing, project-tracker updates, CRM updates | Confirm the exact target, content, and audience before execution. Prefer drafts or dry-runs where available. |
+| Watch/automation | Event watches, digest jobs, workflow syncs, recurring updates, project-tracker automations | Confirm persistence, cleanup behavior, ownership, and notification scope before execution. |
+| Admin/security | BigQuery admin actions, DocuSign RBAC-sensitive actions, ServiceNow-style changes, security/compliance operations | Require explicit user authorization and least-privilege auth. Stop if the connector cannot show scope or target clearly. |
+
+## Probe Summary
+
+The Codex mapping was based on unauthenticated MCP `initialize` probes. Included
+endpoints returned `200` initialize success or `401`/`403` auth challenges that
+indicate a reachable MCP surface. Omitted endpoints returned:
+
+- `apollo`: `404`
+- `datadog`: `404`
+- `github`: `404`
+- `gmail`: `404` from the Claude-hosted endpoint
+- `google-calendar`: `404` from the Claude-hosted endpoint
+- `google-drive`: DNS resolution failure
+- `outreach`: DNS resolution failure
+- `pendo`: DNS resolution failure
+- `servicenow`: DNS resolution failure

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -5,47 +5,97 @@ not a Codex migration approval list. Preserve existing MCP behavior by default; 
 native Codex app/connector looks materially better for a specific dependency,
 open a GitHub issue instead of silently substituting it.
 
-Connector-heavy domain pack review is tracked in
-[issue #25](https://github.com/grailautomation/claude-plugins/issues/25).
+Connector-heavy domain pack review is resolved in
+[issue #25](https://github.com/grailautomation/claude-plugins/issues/25). See
+[DOMAIN_PACKS_CODEX.md](DOMAIN_PACKS_CODEX.md) for pack-level Codex mappings,
+omissions, and side-effect expectations.
 
 ## Current Servers
 
 | Server | Kind | Current config | Used by | Env vars | Current disposition |
 | --- | --- | --- | --- | --- | --- |
-| `amplitude` | HTTP MCP | `https://mcp.amplitude.com/mcp` | `data`, `product-management` |  | Existing MCP behavior review required |
-| `apollo` | HTTP MCP | `https://api.apollo.io/mcp` | `sales` |  | Existing MCP behavior review required |
-| `asana` | HTTP MCP | `https://mcp.asana.com/v2/mcp` | `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity` |  | Existing MCP behavior review required |
-| `atlassian` | HTTP MCP | `https://mcp.atlassian.com/v1/mcp` | `data`, `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
-| `bigquery` | HTTP MCP | `https://bigquery.googleapis.com/mcp` | `data`, `finance` |  | Existing MCP behavior review required |
-| `clay` | HTTP MCP | `https://api.clay.com/v3/mcp` | `sales` |  | Existing MCP behavior review required |
-| `clickup` | HTTP MCP | `https://mcp.clickup.com/mcp` | `product-management`, `productivity` |  | Existing MCP behavior review required |
-| `close` | HTTP MCP | `https://mcp.close.com/mcp` | `sales` |  | Existing MCP behavior review required |
+| `amplitude` | HTTP MCP | `https://mcp.amplitude.com/mcp` | `data`, `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `apollo` | HTTP MCP | `https://api.apollo.io/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `asana` | HTTP MCP | `https://mcp.asana.com/v2/mcp` | `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `atlassian` | HTTP MCP | `https://mcp.atlassian.com/v1/mcp` | `data`, `design`, `engineering`, `enterprise-search`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `bigquery` | HTTP MCP | `https://bigquery.googleapis.com/mcp` | `data`, `finance` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `clay` | HTTP MCP | `https://api.clay.com/v3/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `clickup` | HTTP MCP | `https://mcp.clickup.com/mcp` | `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `close` | HTTP MCP | `https://mcp.close.com/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `cloudflare` | local npm MCP | `npx -y @grailautomation/cloudflare-mcp` | `cloudflare` | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` | Public Claude and Codex plugin; npm package exists at `0.1.0`; published `npx` tools/list smoke passed with 28 tools |
 | `context7` | local npm MCP | `npx -y @upstash/context7-mcp` | `context7` |  | Public Claude and Codex plugin; npm package latest observed at `2.2.5`; published `npx` tools/list smoke passed with 2 tools |
-| `datadog` | HTTP MCP | `https://mcp.datadoghq.com/mcp` | `engineering` |  | Existing MCP behavior review required |
-| `docusign` | HTTP MCP | `https://mcp.docusign.com/mcp` | `legal` |  | Existing MCP behavior review required |
-| `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Existing MCP behavior review required |
-| `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Existing MCP behavior review required |
-| `github` | HTTP MCP | `https://api.github.com/mcp` | `engineering` |  | Existing MCP behavior review required |
-| `gmail` | HTTP MCP | `https://gmail.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
-| `google-calendar` | HTTP MCP | `https://gcal.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
-| `google-drive` | HTTP MCP | `https://google-drive-mcp.claude.com/mcp` | `legal` |  | Existing MCP behavior review required |
-| `guru` | HTTP MCP | `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Existing MCP behavior review required |
-| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Existing MCP behavior review required |
-| `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Existing MCP behavior review required |
-| `intercom` | HTTP MCP | `https://mcp.intercom.com/mcp` | `design`, `product-management` |  | Existing MCP behavior review required |
-| `linear` | HTTP MCP | `https://mcp.linear.app/mcp` | `design`, `engineering`, `product-management`, `productivity` |  | Existing MCP behavior review required |
-| `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Existing MCP behavior review required |
-| `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Existing MCP behavior review required |
+| `datadog` | HTTP MCP | `https://mcp.datadoghq.com/mcp` | `engineering` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `docusign` | HTTP MCP | `https://mcp.docusign.com/mcp` | `legal` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `github` | HTTP MCP | `https://api.github.com/mcp` | `engineering` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `gmail` | HTTP MCP | `https://gmail.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `google-calendar` | HTTP MCP | `https://gcal.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `google-drive` | HTTP MCP | `https://google-drive-mcp.claude.com/mcp` | `legal` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `guru` | HTTP MCP | `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `intercom` | HTTP MCP | `https://mcp.intercom.com/mcp` | `design`, `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `linear` | HTTP MCP | `https://mcp.linear.app/mcp` | `design`, `engineering`, `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `namecheap` | local npm MCP | `npx -y @grailautomation/namecheap-mcp` | `namecheap` | `NAMECHEAP_API_KEY`, `NAMECHEAP_API_USER`, `NAMECHEAP_USERNAME` | Public Claude and Codex plugin; npm package exists at `0.1.0`; published `npx` tools/list smoke passed with 8 tools |
-| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
-| `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Existing MCP behavior review required |
-| `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Existing MCP behavior review required |
-| `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Existing MCP behavior review required |
-| `servicenow` | HTTP MCP | `https://mcp.servicenow.com/mcp` | `operations` |  | Existing MCP behavior review required |
-| `similarweb` | HTTP MCP | `https://mcp.similarweb.com/mcp` | `product-management`, `sales` |  | Existing MCP behavior review required |
-| `slack` | HTTP MCP | `https://mcp.slack.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Existing MCP behavior review required |
-| `zoominfo` | HTTP MCP | `https://mcp.zoominfo.com/mcp` | `sales` |  | Existing MCP behavior review required |
+| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `servicenow` | HTTP MCP | `https://mcp.servicenow.com/mcp` | `operations` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `similarweb` | HTTP MCP | `https://mcp.similarweb.com/mcp` | `product-management`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `slack` | HTTP MCP | `https://mcp.slack.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+| `zoominfo` | HTTP MCP | `https://mcp.zoominfo.com/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
+
+## Hosted HTTP MCP Dispositions
+
+The connector-heavy domain packs preserve their Claude `.mcp.json` files. Codex
+uses pack-local `.mcp.codex.json` files that include only endpoints that
+responded to a non-auth MCP `initialize` probe with either initialize success or
+an auth/RBAC challenge. Endpoints that returned `404` or failed DNS resolution
+are intentionally omitted from Codex configs until a specific issue chooses a
+fix or replacement.
+
+| Server | Codex disposition | Auth/setup expectation |
+| --- | --- | --- |
+| `amplitude` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `apollo` | Omitted from Codex filtered configs | Probe returned `404`; preserve Claude config only until a specific fix/replacement issue exists. |
+| `asana` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `atlassian` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `bigquery` | Included in filtered Codex MCP configs | MCP initialize returned `200`; Google auth/project permissions required for tools. |
+| `clay` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user login/OAuth setup required. |
+| `clickup` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `close` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
+| `datadog` | Omitted from Codex filtered configs | Probe returned `404`; preserve Claude config only until a specific fix/replacement issue exists. |
+| `docusign` | Included in filtered Codex MCP configs | Endpoint reached RBAC access denial; user auth and account/RBAC setup required. |
+| `figma` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `fireflies` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
+| `github` | Omitted from Codex filtered configs | Probe returned `404`; no native-connector substitution in this repo without a specific issue. |
+| `gmail` | Omitted from Codex filtered configs | Claude-hosted endpoint returned `404`; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
+| `google-calendar` | Omitted from Codex filtered configs | Claude-hosted endpoint returned `404`; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
+| `google-drive` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `guru` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
+| `hex` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user auth setup required. |
+| `hubspot` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `intercom` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `linear` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `monday` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `ms365` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; Microsoft auth setup required. |
+| `notion` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
+| `outreach` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `pagerduty` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
+| `pendo` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `servicenow` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `similarweb` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; API key or bearer-token setup required. |
+| `slack` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token/OAuth setup required. |
+| `zoominfo` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
+
+Side-effect expectations for the domain packs are documented in
+[DOMAIN_PACKS_CODEX.md](DOMAIN_PACKS_CODEX.md). Authenticated live workflow
+smoke tests remain install/runtime validation because they require user-specific
+SaaS OAuth, scopes, workspaces, and target records.
 
 ## Review Rules
 

--- a/data/.codex-plugin/plugin.json
+++ b/data/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "data",
+  "version": "0.1.0",
+  "description": "Write SQL, explore datasets, build dashboards, and generate stakeholder-ready data insights with optional MCP-backed data tools.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/data",
+  "keywords": ["data", "sql", "analytics", "dashboards", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Data",
+    "shortDescription": "Analyze data and write SQL",
+    "longDescription": "Use Data to write SQL, explore datasets, validate analyses, create visualizations, and build dashboards. Codex uses the filtered MCP config for reachable hosted MCP endpoints and falls back to pasted files or manual query results when tools are not authenticated.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use data to analyze this dataset",
+      "Use data to write a SQL query",
+      "Use data to validate this analysis"
+    ],
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/data/.mcp.codex.json
+++ b/data/.mcp.codex.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "bigquery": {
+      "type": "http",
+      "url": "https://bigquery.googleapis.com/mcp"
+    },
+    "hex": {
+      "type": "http",
+      "url": "https://app.hex.tech/mcp"
+    },
+    "amplitude": {
+      "type": "http",
+      "url": "https://mcp.amplitude.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    }
+  }
+}

--- a/design/.codex-plugin/plugin.json
+++ b/design/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "design",
+  "version": "0.1.0",
+  "description": "Critique designs, manage design systems, write UX copy, audit accessibility, synthesize research, and prepare developer handoff.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/design",
+  "keywords": ["design", "figma", "accessibility", "handoff", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Design",
+    "shortDescription": "Design critique and handoff",
+    "longDescription": "Use Design to critique interfaces, manage design systems, improve UX writing, audit accessibility, synthesize user research, and produce developer handoff material with optional MCP-backed design and planning tools.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use design to critique this UI",
+      "Use design to prepare a handoff spec",
+      "Use design to review accessibility"
+    ],
+    "brandColor": "#A855F7",
+    "screenshots": []
+  }
+}

--- a/design/.mcp.codex.json
+++ b/design/.mcp.codex.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "intercom": {
+      "type": "http",
+      "url": "https://mcp.intercom.com/mcp"
+    }
+  }
+}

--- a/engineering/.codex-plugin/plugin.json
+++ b/engineering/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "engineering",
+  "version": "0.1.0",
+  "description": "Support engineering standups, code review, debugging, architecture decisions, incidents, and technical documentation.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/engineering",
+  "keywords": ["engineering", "code-review", "incident", "architecture", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Engineering",
+    "shortDescription": "Engineering workflows",
+    "longDescription": "Use Engineering for standups, code review, debugging, architecture decisions, incident response, deployment checklists, and technical documentation with optional MCP-backed work tools.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use engineering to review this code",
+      "Use engineering to prepare an incident update",
+      "Use engineering to draft an architecture decision"
+    ],
+    "brandColor": "#0F172A",
+    "screenshots": []
+  }
+}

--- a/engineering/.mcp.codex.json
+++ b/engineering/.mcp.codex.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "pagerduty": {
+      "type": "http",
+      "url": "https://mcp.pagerduty.com/mcp"
+    }
+  }
+}

--- a/enterprise-search/.codex-plugin/plugin.json
+++ b/enterprise-search/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "enterprise-search",
+  "version": "0.1.0",
+  "description": "Search and synthesize across connected company tools such as chat, docs, knowledge bases, project trackers, and office suites.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/enterprise-search",
+  "keywords": ["enterprise-search", "knowledge", "search", "synthesis", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Enterprise Search",
+    "shortDescription": "Search connected work tools",
+    "longDescription": "Use Enterprise Search to decompose questions, search connected work tools, and synthesize results with source attribution. Codex uses the filtered MCP config for reachable hosted endpoints.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use enterprise-search to find decisions about this project",
+      "Use enterprise-search to create a weekly digest",
+      "Use enterprise-search to find relevant docs"
+    ],
+    "brandColor": "#0891B2",
+    "screenshots": []
+  }
+}

--- a/enterprise-search/.mcp.codex.json
+++ b/enterprise-search/.mcp.codex.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "guru": {
+      "type": "http",
+      "url": "https://mcp.api.getguru.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/finance/.codex-plugin/plugin.json
+++ b/finance/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "finance",
+  "version": "0.1.0",
+  "description": "Support finance workflows including journal entries, reconciliation, statements, variance analysis, audit prep, and month-end close.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/finance",
+  "keywords": ["finance", "accounting", "audit", "variance", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Finance",
+    "shortDescription": "Finance and accounting workflows",
+    "longDescription": "Use Finance to prepare journal entries, reconcile accounts, analyze variances, support audits, organize close workflows, and draft financial statements with optional MCP-backed data and communication tools.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use finance to analyze this variance",
+      "Use finance to prepare a reconciliation",
+      "Use finance to support month-end close"
+    ],
+    "brandColor": "#16A34A",
+    "screenshots": []
+  }
+}

--- a/finance/.mcp.codex.json
+++ b/finance/.mcp.codex.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "bigquery": {
+      "type": "http",
+      "url": "https://bigquery.googleapis.com/mcp"
+    },
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/legal/.codex-plugin/plugin.json
+++ b/legal/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "legal",
+  "version": "0.1.0",
+  "description": "Support contract review, NDA triage, compliance checks, legal briefs, vendor checks, and signature-request workflows.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/legal",
+  "keywords": ["legal", "contracts", "compliance", "docusign", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Legal",
+    "shortDescription": "Legal workflow support",
+    "longDescription": "Use Legal for contract review, NDA triage, compliance checks, legal-risk assessment, meeting briefings, vendor checks, and signature-request preparation with optional MCP-backed systems.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use legal to review this contract",
+      "Use legal to triage this NDA",
+      "Use legal to prepare a signature request"
+    ],
+    "brandColor": "#7C3AED",
+    "screenshots": []
+  }
+}

--- a/legal/.mcp.codex.json
+++ b/legal/.mcp.codex.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "docusign": {
+      "type": "http",
+      "url": "https://mcp.docusign.com/mcp"
+    },
+    "hubspot": {
+      "type": "http",
+      "url": "https://mcp.hubspot.com/anthropic"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    }
+  }
+}

--- a/operations/.codex-plugin/plugin.json
+++ b/operations/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "operations",
+  "version": "0.1.0",
+  "description": "Support business operations workflows including vendor management, process documentation, change requests, capacity planning, and compliance tracking.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/operations",
+  "keywords": ["operations", "vendor-management", "runbooks", "change-management", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Operations",
+    "shortDescription": "Business operations workflows",
+    "longDescription": "Use Operations to evaluate vendors, document processes, plan changes, model capacity, track compliance, prepare status reports, and write runbooks with optional MCP-backed business systems.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use operations to evaluate this vendor",
+      "Use operations to document this process",
+      "Use operations to prepare a change request"
+    ],
+    "brandColor": "#EA580C",
+    "screenshots": []
+  }
+}

--- a/operations/.mcp.codex.json
+++ b/operations/.mcp.codex.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/product-management/.codex-plugin/plugin.json
+++ b/product-management/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "product-management",
+  "version": "0.1.0",
+  "description": "Support product-management workflows including feature specs, roadmaps, research synthesis, stakeholder updates, metrics review, and competitive analysis.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/product-management",
+  "keywords": ["product-management", "roadmap", "research", "metrics", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Product Management",
+    "shortDescription": "Product management workflows",
+    "longDescription": "Use Product Management to write specs, plan roadmaps, synthesize research, review metrics, prepare competitive briefs, and update stakeholders with optional MCP-backed product tools.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use product-management to write a feature spec",
+      "Use product-management to synthesize this research",
+      "Use product-management to review product metrics"
+    ],
+    "brandColor": "#DB2777",
+    "screenshots": []
+  }
+}

--- a/product-management/.mcp.codex.json
+++ b/product-management/.mcp.codex.json
@@ -1,0 +1,52 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "monday": {
+      "type": "http",
+      "url": "https://mcp.monday.com/mcp"
+    },
+    "clickup": {
+      "type": "http",
+      "url": "https://mcp.clickup.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "amplitude": {
+      "type": "http",
+      "url": "https://mcp.amplitude.com/mcp"
+    },
+    "intercom": {
+      "type": "http",
+      "url": "https://mcp.intercom.com/mcp"
+    },
+    "fireflies": {
+      "type": "http",
+      "url": "https://api.fireflies.ai/mcp"
+    },
+    "similarweb": {
+      "type": "http",
+      "url": "https://mcp.similarweb.com/mcp"
+    }
+  }
+}

--- a/productivity/.codex-plugin/plugin.json
+++ b/productivity/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "productivity",
+  "version": "0.1.0",
+  "description": "Manage tasks, plan work, and build workplace memory with optional chat, project-tracker, knowledge-base, and office-suite integrations.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/productivity",
+  "keywords": ["productivity", "tasks", "memory", "dashboard", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Productivity",
+    "shortDescription": "Tasks and workplace memory",
+    "longDescription": "Use Productivity to manage local task lists, build workplace memory, and sync context from authenticated work tools where available. This plugin can write local task and memory files.",
+    "developerName": "Grail Automation",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use productivity to start a task list",
+      "Use productivity to update stale tasks",
+      "Use productivity to capture workplace memory"
+    ],
+    "brandColor": "#14B8A6",
+    "screenshots": []
+  }
+}

--- a/productivity/.mcp.codex.json
+++ b/productivity/.mcp.codex.json
@@ -1,0 +1,36 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "monday": {
+      "type": "http",
+      "url": "https://mcp.monday.com/mcp"
+    },
+    "clickup": {
+      "type": "http",
+      "url": "https://mcp.clickup.com/mcp"
+    }
+  }
+}

--- a/sales/.codex-plugin/plugin.json
+++ b/sales/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "sales",
+  "version": "0.1.0",
+  "description": "Support sales workflows including prospect research, call prep, outreach, pipeline review, forecasting, and competitive intelligence.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/sales",
+  "keywords": ["sales", "crm", "outreach", "pipeline", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Sales",
+    "shortDescription": "Sales workflow support",
+    "longDescription": "Use Sales to research accounts, prepare for calls, draft outreach, review pipeline, build forecasts, create sales assets, and analyze competitors with optional MCP-backed CRM, enrichment, transcript, and communication tools.",
+    "developerName": "Grail Automation",
+    "category": "Integrations",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Use sales to research this account",
+      "Use sales to draft outreach",
+      "Use sales to review this pipeline"
+    ],
+    "brandColor": "#DC2626",
+    "screenshots": []
+  }
+}

--- a/sales/.mcp.codex.json
+++ b/sales/.mcp.codex.json
@@ -1,0 +1,44 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "hubspot": {
+      "type": "http",
+      "url": "https://mcp.hubspot.com/anthropic"
+    },
+    "close": {
+      "type": "http",
+      "url": "https://mcp.close.com/mcp"
+    },
+    "clay": {
+      "type": "http",
+      "url": "https://api.clay.com/v3/mcp"
+    },
+    "zoominfo": {
+      "type": "http",
+      "url": "https://mcp.zoominfo.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "fireflies": {
+      "type": "http",
+      "url": "https://api.fireflies.ai/mcp"
+    },
+    "ms365": {
+      "type": "http",
+      "url": "https://microsoft365.mcp.claude.com/mcp"
+    },
+    "similarweb": {
+      "type": "http",
+      "url": "https://mcp.similarweb.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add Codex manifests and marketplace entries for the ten connector-heavy domain packs.
- Preserve each Claude `.mcp.json` and add filtered `.mcp.codex.json` files for Codex.
- Document pack-level included/omitted endpoints, auth/setup expectations, and side-effect classes in `DOMAIN_PACKS_CODEX.md`.
- Update `MCP_INVENTORY.md` dispositions from review-needed to concrete Codex included/omitted decisions.

Resolves #25

## Validation
- Refreshed official Codex docs: plugins can include root `.mcp.json`; Codex supports Streamable HTTP MCP with OAuth.
- MCP initialize probes against hosted endpoints; included endpoints returned initialize success or auth/RBAC challenges, omitted endpoints returned 404 or DNS failures.
- ruby scripts/validate_repo.rb
- jq empty .agents/plugins/marketplace.json */.codex-plugin/plugin.json {data,design,engineering,enterprise-search,finance,legal,operations,product-management,productivity,sales}/.mcp.codex.json
- claude plugin validate data/design/engineering/enterprise-search/finance/legal/operations/product-management/productivity/sales (passes with existing missing-version warnings)
- git diff --check
- filtered MCP config mapping check script

## Notes
- No native Codex connector substitution was made.
- Authenticated SaaS workflow smoke tests remain install/runtime validation because they require user-specific OAuth/scopes/workspaces/target records.
- Claude marketplace behavior is unchanged; original `.mcp.json` files are preserved.