### PR TITLE
Validate Codex MCP configs

### DIFF
--- a/scripts/validate_repo.rb
+++ b/scripts/validate_repo.rb
@@ -285,7 +285,7 @@ codex_manifests.each do |manifest_path|
   error.call(manifest_path, "Codex manifest exists but plugin is not listed in #{codex_marketplace_path}")
 end
 
-mcp_files = files.select { |path| path.end_with?("/.mcp.json") }
+mcp_files = files.select { |path| path.match?(%r{/\.mcp(?:\.codex)?\.json\z}) }
 mcp_files.each do |relative_path|
   config = json_cache[relative_path]
   servers = config&.fetch("mcpServers", nil)


### PR DESCRIPTION
## Summary
- Include `.mcp.codex.json` files in the repository MCP config validator.
- Keep the same validation rules for original Claude MCP configs and Codex filtered MCP configs.

## Validation
- ruby scripts/validate_repo.rb
- ruby -c scripts/validate_repo.rb
- git diff --check