### PR TITLE
Resolve omitted MCP endpoints

### DIFF
--- a/DOMAIN_PACKS_CODEX.md
+++ b/DOMAIN_PACKS_CODEX.md
@@ -29,14 +29,14 @@ valid initialize response or an auth/RBAC challenge.
 | --- | --- | --- | --- |
 | `data` | `.mcp.codex.json` | `bigquery`, `hex`, `amplitude`, `atlassian` | None |
 | `design` | `.mcp.codex.json` | `slack`, `figma`, `linear`, `asana`, `atlassian`, `notion`, `intercom` | `google-calendar`, `gmail` |
-| `engineering` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `atlassian`, `notion`, `pagerduty` | `github`, `datadog`, `google-calendar`, `gmail` |
+| `engineering` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `atlassian`, `notion`, `github`, `pagerduty`, `datadog` | `google-calendar`, `gmail` |
 | `enterprise-search` | `.mcp.codex.json` | `slack`, `notion`, `guru`, `atlassian`, `asana`, `ms365` | `google-calendar`, `gmail` |
 | `finance` | `.mcp.codex.json` | `bigquery`, `slack`, `ms365` | `google-calendar`, `gmail` |
 | `legal` | `.mcp.codex.json` | `slack`, `docusign`, `hubspot`, `notion` | `google-calendar`, `gmail`, `google-drive` |
 | `operations` | `.mcp.codex.json` | `slack`, `notion`, `atlassian`, `asana`, `ms365` | `google-calendar`, `gmail`, `servicenow` |
 | `product-management` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `monday`, `clickup`, `atlassian`, `notion`, `figma`, `amplitude`, `intercom`, `fireflies`, `similarweb` | `pendo`, `google-calendar`, `gmail` |
 | `productivity` | `.mcp.codex.json` | `slack`, `notion`, `asana`, `linear`, `atlassian`, `ms365`, `monday`, `clickup` | `google-calendar`, `gmail` |
-| `sales` | `.mcp.codex.json` | `slack`, `hubspot`, `close`, `clay`, `zoominfo`, `notion`, `atlassian`, `fireflies`, `ms365`, `similarweb` | `apollo`, `outreach`, `google-calendar`, `gmail` |
+| `sales` | `.mcp.codex.json` | `slack`, `hubspot`, `close`, `clay`, `zoominfo`, `notion`, `atlassian`, `fireflies`, `ms365`, `outreach`, `similarweb` | `apollo`, `google-calendar`, `gmail` |
 
 ## Side-Effect Expectations
 
@@ -51,14 +51,24 @@ valid initialize response or an auth/RBAC challenge.
 
 The Codex mapping was based on unauthenticated MCP `initialize` probes. Included
 endpoints returned `200` initialize success or `401`/`403` auth challenges that
-indicate a reachable MCP surface. Omitted endpoints returned:
+indicate a reachable MCP surface. Some Codex endpoints intentionally differ from
+the preserved Claude `.mcp.json` because the Claude value failed probing and a
+current public vendor endpoint was available:
 
-- `apollo`: `404`
-- `datadog`: `404`
-- `github`: `404`
+- `datadog`: Codex uses `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp`.
+- `github`: Codex uses `https://api.githubcopilot.com/mcp/`.
+- `outreach`: Codex uses `https://api.outreach.io/mcp/`.
+
+Remaining omitted endpoints have these final dispositions:
+
+- `apollo`: the configured URL returned `404`; Apollo's public MCP guidance points
+  users to hosted connector directories rather than a stable server URL to commit.
 - `gmail`: `404` from the Claude-hosted endpoint
 - `google-calendar`: `404` from the Claude-hosted endpoint
-- `google-drive`: DNS resolution failure
-- `outreach`: DNS resolution failure
-- `pendo`: DNS resolution failure
-- `servicenow`: DNS resolution failure
+- `google-drive`: DNS resolution failure for the configured Claude-hosted
+  endpoint
+- `pendo`: no universal default; the documented Pendo MCP URL is regional and
+  must match the user's sign-in hostname
+- `servicenow`: the configured shared host did not resolve; ServiceNow documents
+  instance-generated server URLs of the form
+  `https://<instance>.service-now.com/sncapps/mcp-server/mcp/<server-name>`

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -61,21 +61,21 @@ fix or replacement.
 | Server | Codex disposition | Auth/setup expectation |
 | --- | --- | --- |
 | `amplitude` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
-| `apollo` | Omitted from Codex filtered configs | Probe returned `404`; preserve Claude config only until a specific fix/replacement issue exists. |
+| `apollo` | Omitted from Codex filtered configs | The configured URL returned `404`; Apollo's public MCP guidance points users to hosted connector directories rather than a stable server URL to commit. |
 | `asana` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `atlassian` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `bigquery` | Included in filtered Codex MCP configs | MCP initialize returned `200`; Google auth/project permissions required for tools. |
 | `clay` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user login/OAuth setup required. |
 | `clickup` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `close` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
-| `datadog` | Omitted from Codex filtered configs | Probe returned `404`; preserve Claude config only until a specific fix/replacement issue exists. |
+| `datadog` | Included in filtered Codex MCP configs with corrected Codex URL | Original Claude URL returned `404`; Codex uses `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp`, which reached an auth challenge. User OAuth/token setup required. |
 | `docusign` | Included in filtered Codex MCP configs | Endpoint reached RBAC access denial; user auth and account/RBAC setup required. |
 | `figma` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `fireflies` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
-| `github` | Omitted from Codex filtered configs | Probe returned `404`; no native-connector substitution in this repo without a specific issue. |
+| `github` | Included in filtered Codex MCP configs with corrected Codex URL | Original Claude URL returned `404`; Codex uses `https://api.githubcopilot.com/mcp/`, which reached an auth challenge. User GitHub Copilot/GitHub auth setup required. |
 | `gmail` | Omitted from Codex filtered configs | Claude-hosted endpoint returned `404`; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
 | `google-calendar` | Omitted from Codex filtered configs | Claude-hosted endpoint returned `404`; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
-| `google-drive` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `google-drive` | Omitted from Codex filtered configs | The configured Claude-hosted endpoint did not resolve from this network; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
 | `guru` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
 | `hex` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user auth setup required. |
 | `hubspot` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
@@ -84,10 +84,10 @@ fix or replacement.
 | `monday` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `ms365` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; Microsoft auth setup required. |
 | `notion` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
-| `outreach` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `outreach` | Included in filtered Codex MCP configs with corrected Codex URL | Original Claude host did not resolve; Codex uses `https://api.outreach.io/mcp/`, which reached an auth challenge. Outreach Amplify/org enablement and user auth required. |
 | `pagerduty` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
-| `pendo` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
-| `servicenow` | Omitted from Codex filtered configs | Host did not resolve; preserve Claude config only until a specific fix/replacement issue exists. |
+| `pendo` | Omitted from Codex filtered configs | The existing URL did not resolve from this network, and Pendo documents regional MCP URLs that must match the user's sign-in hostname; no universal public default is committed. |
+| `servicenow` | Omitted from Codex filtered configs | The configured shared host did not resolve; ServiceNow documents instance-generated server URLs of the form `https://<instance>.service-now.com/sncapps/mcp-server/mcp/<server-name>`, so no public shared default is committed. |
 | `similarweb` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; API key or bearer-token setup required. |
 | `slack` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token/OAuth setup required. |
 | `zoominfo` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |

--- a/engineering/.mcp.codex.json
+++ b/engineering/.mcp.codex.json
@@ -20,9 +20,17 @@
       "type": "http",
       "url": "https://mcp.notion.com/mcp"
     },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
     "pagerduty": {
       "type": "http",
       "url": "https://mcp.pagerduty.com/mcp"
+    },
+    "datadog": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
     }
   }
 }

--- a/sales/.mcp.codex.json
+++ b/sales/.mcp.codex.json
@@ -36,6 +36,10 @@
       "type": "http",
       "url": "https://microsoft365.mcp.claude.com/mcp"
     },
+    "outreach": {
+      "type": "http",
+      "url": "https://api.outreach.io/mcp/"
+    },
     "similarweb": {
       "type": "http",
       "url": "https://mcp.similarweb.com/mcp"


### PR DESCRIPTION
## Summary
- Add corrected Codex MCP endpoints for Datadog, GitHub, and Outreach after primary-source lookup and MCP initialize probes.
- Keep Apollo, Google Workspace Claude-hosted endpoints, Google Drive, Pendo, and ServiceNow omitted with final documented rationale.
- Update domain-pack and MCP inventory docs to distinguish preserved Claude configs from corrected Codex filtered configs.

Resolves #40

## Validation
- MCP initialize probes for corrected endpoints:
  - Datadog: `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp` returned 401 auth challenge
  - GitHub: `https://api.githubcopilot.com/mcp/` returned 401 auth challenge
  - Outreach: `https://api.outreach.io/mcp/` returned 401 auth challenge
- ruby scripts/validate_repo.rb
- jq empty engineering/.mcp.codex.json sales/.mcp.codex.json .agents/plugins/marketplace.json
- claude plugin validate engineering && claude plugin validate sales (passes with existing missing-version warnings)
- git diff --check

## Sources checked
- Datadog official MCP docs/GitHub config
- GitHub official MCP docs
- Outreach support docs
- Pendo support docs for regional MCP URLs
- Apollo product docs
- ServiceNow MCP Server Console docs