### PR TITLE
[codex] Enable Workato Platform CLI Codex invocation

### DIFF
--- a/workato-platform-cli/skills/workato-platform-cli/agents/openai.yaml
+++ b/workato-platform-cli/skills/workato-platform-cli/agents/openai.yaml
@@ -1,2 +1,7 @@
+interface:
+  display_name: "Workato Platform CLI"
+  short_description: "Build safe Workato Platform CLI commands"
+  brand_color: "#F45A2A"
+  default_prompt: "Use $workato-platform-cli to build a safe Workato CLI command."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary
- make the Workato Platform CLI Codex skill implicitly invocable
- add Codex plugin interface metadata so the marketplace plugin cleanly replaces the prior user-level skill

## Validation
- ruby scripts/validate_repo.rb
- git diff --check
- codex debug prompt-input "workato replacement smoke" | rg -n "workato-platform-cli|Workato Platform CLI|Available plugins|Available skills"