### PR TITLE
[codex] Prefer CLI-backed integrations over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,13 @@ Not every plugin uses all component types.
 - Plain Node.js using `@modelcontextprotocol/sdk` with stdio transport
 - Credentials read from environment variables, declared in `.mcp.json` at the plugin root
 - Published to npm as `@grailautomation/<name>-mcp`
+- Prefer CLI-backed integrations over MCP whenever a maintained CLI can safely
+  perform the workflow. This applies to Claude and Codex. Use MCP only when no
+  usable CLI exists, the CLI cannot express the operation safely, or the MCP
+  server itself is the plugin's core value.
+- For Google Workspace, route Gmail, Calendar, Drive, Docs, Sheets, Slides, and
+  related workflows through the `google-workspace` plugin and `gws` CLI, not
+  Gmail/GCal/GDrive MCP endpoints.
 - For plugin-required per-install values, prefer `userConfig` in `plugin.json` and `${user_config.KEY}` substitutions. For optional account/workspace-specific connectors, prefer user/project/local MCP config with environment-variable-backed URLs so broad marketplace plugins do not fail on unset placeholders.
 
 ### Versioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,13 @@ Not every plugin uses all component types.
 - Plain Node.js using `@modelcontextprotocol/sdk` with stdio transport
 - Credentials read from environment variables, declared in `.mcp.json` at the plugin root
 - Published to npm as `@grailautomation/<name>-mcp`
+- Prefer CLI-backed integrations over MCP whenever a maintained CLI can safely
+  perform the workflow. This applies to Claude and Codex. Use MCP only when no
+  usable CLI exists, the CLI cannot express the operation safely, or the MCP
+  server itself is the plugin's core value.
+- For Google Workspace, route Gmail, Calendar, Drive, Docs, Sheets, Slides, and
+  related workflows through the `google-workspace` plugin and `gws` CLI, not
+  Gmail/GCal/GDrive MCP endpoints.
 - For plugin-required per-install values, prefer `userConfig` in `plugin.json` and `${user_config.KEY}` substitutions. For optional account/workspace-specific connectors, prefer user/project/local MCP config with environment-variable-backed URLs so broad marketplace plugins do not fail on unset placeholders.
 
 ### Versioning

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -107,7 +107,7 @@ These are working classifications, not final deletion decisions:
 | `cloudflare`, `namecheap` | `public-marketplace` | Keep in the public Claude marketplace. Credentials, account IDs, whitelisted IPs, and domain lists stay outside the repo in environment variables, account settings, Claude/Codex config, or gitignored local notes. |
 | `issue-blaster` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex uses direct single-issue `gh`/`rg` analysis and explicit user-authorized subagents only for parallelism. |
 | `scraper-generator` | `public-marketplace` | Keep listed for Claude and Codex. Claude keeps slash-command/subagent orchestration; Codex runs phases inline by default and validates generated scrapers with the bundled script. |
-| Domain MCP packs | `public-marketplace` with filtered Codex MCP configs | Keep listed for Claude with the original `.mcp.json`. Codex uses `.mcp.codex.json` per pack, preserving reachable hosted HTTP MCP dependencies and omitting endpoints that failed MCP probes instead of substituting native connectors. |
+| Domain MCP packs | `public-marketplace` with filtered Codex MCP configs | Keep listed for Claude and Codex. Prefer maintained CLIs over MCP whenever a CLI can safely perform the workflow; Gmail, Google Calendar, and Google Drive route through the `google-workspace` / `gws` CLI path. Codex uses `.mcp.codex.json` per pack for remaining reachable hosted HTTP MCP dependencies and omits endpoints that failed MCP probes instead of substituting native connectors. |
 | `google-workspace` | `public-marketplace` | Keep as one broad plugin for Claude and Codex. The integration is CLI-backed rather than MCP-backed; require current `gws` auth and side-effect confirmation instead of splitting by product or action class. |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
 | `espanso`, `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as generic macOS config workflows; do not expose to Codex until a side-effect policy and local-config validation path are deliberately designed. |
@@ -120,9 +120,10 @@ These are working classifications, not final deletion decisions:
 - Add a plugin to `.agents/plugins/marketplace.json` only after its
   `.codex-plugin/plugin.json`, skill metadata, and runtime assumptions have been
   reviewed.
-- Preserve the existing asset architecture by default. Do not replace an
-  MCP-backed workflow with a native Codex app/connector unless there is a
-  documented reason; open a GitHub issue for those exceptions.
+- Preserve the existing asset architecture by default, but prefer maintained
+  CLI-backed workflows over MCP when a CLI can safely perform the operation. Do
+  not replace an MCP-backed workflow with a native Codex app/connector unless
+  there is a documented reason; open a GitHub issue for those exceptions.
 - Prefer `skills/<skill>/agents/openai.yaml` for Codex-only invocation policy
   instead of overloading Claude-specific frontmatter.
 - Do not copy personal author emails into Codex manifests.

--- a/DOMAIN_PACKS_CODEX.md
+++ b/DOMAIN_PACKS_CODEX.md
@@ -4,21 +4,32 @@ This document records the Codex mapping for the connector-heavy domain packs:
 `data`, `design`, `engineering`, `enterprise-search`, `finance`, `legal`,
 `operations`, `product-management`, `productivity`, and `sales`.
 
-The Claude marketplace behavior is preserved. Each pack keeps its original
-`.mcp.json`. Codex uses `.mcp.codex.json`, which includes only hosted HTTP MCP
-endpoints that responded to a non-auth MCP `initialize` probe with either a
-valid initialize response or an auth/RBAC challenge.
+This repo is CLI-first for Claude and Codex. When a maintained CLI can safely
+perform a workflow, prefer that CLI over MCP. Google Workspace is handled
+through the `google-workspace` plugin and `gws` CLI. Domain-pack `.mcp.json`
+files keep remaining MCP dependencies only. Codex additionally uses
+`.mcp.codex.json`, which includes only hosted HTTP MCP endpoints that responded
+to a non-auth MCP `initialize` probe with either a valid initialize response or
+an auth/RBAC challenge.
 
 ## Mapping Rules
 
-- Do not replace a hosted MCP dependency with a native Codex app or connector in
-  these packs unless a specific issue documents the exception.
+- Prefer a maintained CLI over hosted MCP whenever the CLI can safely perform
+  the workflow. Do not replace a hosted MCP dependency with a native app or
+  connector in these packs unless a specific issue documents the exception.
+- Gmail, Google Calendar, and Google Drive are handled through the
+  `google-workspace` plugin and `gws` CLI in Claude and Codex, not through MCP.
+  Domain-pack skills may still use `~~email`, `~~calendar`, and
+  `~~cloud storage` as source labels, but Google-backed execution should route
+  to `gws gmail`, `gws calendar`, or `gws drive` after checking auth with
+  `gws auth status`.
 - Auth is install/runtime user setup. Most included endpoints returned an OAuth,
   bearer-token, API-key, or RBAC challenge during unauthenticated probing.
 - Endpoints that returned `404`, failed DNS resolution, or otherwise did not
   behave like reachable MCP servers are omitted from `.mcp.codex.json`.
-- Omitted endpoints stay in the Claude `.mcp.json` until a separate issue decides
-  whether to fix, replace, or remove them.
+- Omitted non-Google endpoints either stay in the Claude `.mcp.json` until a
+  separate issue decides their fate, or are removed when a CLI-backed path has
+  been chosen and documented.
 - Side-effect boundaries stay workflow-level, not plugin boundaries. Commands
   that write, send, share, invite, watch, subscribe, renew, administer, or change
   external state require user confirmation before execution.
@@ -29,7 +40,7 @@ valid initialize response or an auth/RBAC challenge.
 | --- | --- | --- | --- |
 | `data` | `.mcp.codex.json` | `bigquery`, `hex`, `amplitude`, `atlassian` | None |
 | `design` | `.mcp.codex.json` | `slack`, `figma`, `linear`, `asana`, `atlassian`, `notion`, `intercom` | `google-calendar`, `gmail` |
-| `engineering` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `atlassian`, `notion`, `github`, `pagerduty`, `datadog` | `google-calendar`, `gmail` |
+| `engineering` | `.mcp.codex.json` | `slack`, `linear`, `asana`, `atlassian`, `notion`, `pagerduty`, `datadog` | `github`, `google-calendar`, `gmail` |
 | `enterprise-search` | `.mcp.codex.json` | `slack`, `notion`, `guru`, `atlassian`, `asana`, `ms365` | `google-calendar`, `gmail` |
 | `finance` | `.mcp.codex.json` | `bigquery`, `slack`, `ms365` | `google-calendar`, `gmail` |
 | `legal` | `.mcp.codex.json` | `slack`, `docusign`, `hubspot`, `notion` | `google-calendar`, `gmail`, `google-drive` |
@@ -52,21 +63,23 @@ valid initialize response or an auth/RBAC challenge.
 The Codex mapping was based on unauthenticated MCP `initialize` probes. Included
 endpoints returned `200` initialize success or `401`/`403` auth challenges that
 indicate a reachable MCP surface. Some Codex endpoints intentionally differ from
-the preserved Claude `.mcp.json` because the Claude value failed probing and a
-current public vendor endpoint was available:
+the corresponding Claude `.mcp.json` value failed probing and a current public
+vendor endpoint was available:
 
 - `datadog`: Codex uses `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp`.
-- `github`: Codex uses `https://api.githubcopilot.com/mcp/`.
 - `outreach`: Codex uses `https://api.outreach.io/mcp/`.
 
 Remaining omitted endpoints have these final dispositions:
 
 - `apollo`: the configured URL returned `404`; Apollo's public MCP guidance points
   users to hosted connector directories rather than a stable server URL to commit.
-- `gmail`: `404` from the Claude-hosted endpoint
-- `google-calendar`: `404` from the Claude-hosted endpoint
-- `google-drive`: DNS resolution failure for the configured Claude-hosted
-  endpoint
+- `github`: handled through the `gh` CLI for GitHub work in Claude and Codex
+- `gmail`: handled by the `google-workspace` plugin and `gws gmail` in Claude
+  and Codex
+- `google-calendar`: handled by the `google-workspace` plugin and
+  `gws calendar` in Claude and Codex
+- `google-drive`: handled by the `google-workspace` plugin and `gws drive` in
+  Claude and Codex
 - `pendo`: no universal default; the documented Pendo MCP URL is regional and
   must match the user's sign-in hostname
 - `servicenow`: the configured shared host did not resolve; ServiceNow documents

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -1,9 +1,15 @@
 # MCP Inventory
 
 This inventory reflects the tracked `.mcp.json` files in this repository. It is
-not a Codex migration approval list. Preserve existing MCP behavior by default; if a
-native Codex app/connector looks materially better for a specific dependency,
-open a GitHub issue instead of silently substituting it.
+not a Codex migration approval list. This repo is CLI-first: when a maintained
+CLI can safely perform a workflow, prefer that CLI over MCP for both Claude and
+Codex.
+
+MCP remains appropriate when no usable CLI exists, the CLI cannot express the
+operation safely, or the MCP server is itself the plugin's core value. Google
+Workspace is the concrete enforced case here: Gmail, Google Calendar, and
+Google Drive route through the `google-workspace` plugin and `gws` CLI rather
+than Gmail/GCal/GDrive MCP endpoints.
 
 Connector-heavy domain pack review is resolved in
 [issue #25](https://github.com/grailautomation/claude-plugins/issues/25). See
@@ -28,10 +34,6 @@ omissions, and side-effect expectations.
 | `docusign` | HTTP MCP | `https://mcp.docusign.com/mcp` | `legal` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
-| `github` | HTTP MCP | `https://api.github.com/mcp` | `engineering` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
-| `gmail` | HTTP MCP | `https://gmail.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
-| `google-calendar` | HTTP MCP | `https://gcal.mcp.claude.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
-| `google-drive` | HTTP MCP | `https://google-drive-mcp.claude.com/mcp` | `legal` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `guru` | HTTP MCP | `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
@@ -51,12 +53,13 @@ omissions, and side-effect expectations.
 
 ## Hosted HTTP MCP Dispositions
 
-The connector-heavy domain packs preserve their Claude `.mcp.json` files. Codex
-uses pack-local `.mcp.codex.json` files that include only endpoints that
-responded to a non-auth MCP `initialize` probe with either initialize success or
-an auth/RBAC challenge. Endpoints that returned `404` or failed DNS resolution
-are intentionally omitted from Codex configs until a specific issue chooses a
-fix or replacement.
+The connector-heavy domain packs use MCP for non-Google hosted providers and
+the `google-workspace` / `gws` CLI path for Gmail, Google Calendar, and Google
+Drive. Codex uses pack-local `.mcp.codex.json` files that include only
+endpoints that responded to a non-auth MCP `initialize` probe with either
+initialize success or an auth/RBAC challenge. Endpoints that returned `404` or
+failed DNS resolution are intentionally omitted from Codex configs until a
+specific issue chooses a fix or replacement.
 
 | Server | Codex disposition | Auth/setup expectation |
 | --- | --- | --- |
@@ -72,10 +75,10 @@ fix or replacement.
 | `docusign` | Included in filtered Codex MCP configs | Endpoint reached RBAC access denial; user auth and account/RBAC setup required. |
 | `figma` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `fireflies` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
-| `github` | Included in filtered Codex MCP configs with corrected Codex URL | Original Claude URL returned `404`; Codex uses `https://api.githubcopilot.com/mcp/`, which reached an auth challenge. User GitHub Copilot/GitHub auth setup required. |
-| `gmail` | Omitted from Codex filtered configs | Claude-hosted endpoint returned `404`; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
-| `google-calendar` | Omitted from Codex filtered configs | Claude-hosted endpoint returned `404`; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
-| `google-drive` | Omitted from Codex filtered configs | The configured Claude-hosted endpoint did not resolve from this network; use the separate `google-workspace` CLI plugin for Codex Google Workspace work. |
+| `github` | Removed from engineering MCP configs | Use the `gh` CLI for GitHub work in Claude and Codex. Do not add GitHub MCP unless a future issue documents why CLI is insufficient. |
+| `gmail` | Removed from domain-pack MCP configs | Use the separate `google-workspace` CLI plugin and `gws gmail` for Google Workspace work. Do not add Gmail MCP unless a future issue documents why CLI is insufficient. |
+| `google-calendar` | Removed from domain-pack MCP configs | Use the separate `google-workspace` CLI plugin and `gws calendar` for Google Workspace work. Do not add Google Calendar MCP unless a future issue documents why CLI is insufficient. |
+| `google-drive` | Removed from domain-pack MCP configs | Use the separate `google-workspace` CLI plugin and `gws drive` for Google Workspace work. Do not add Google Drive MCP unless a future issue documents why CLI is insufficient. |
 | `guru` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
 | `hex` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user auth setup required. |
 | `hubspot` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
@@ -100,11 +103,15 @@ SaaS OAuth, scopes, workspaces, and target records.
 ## Review Rules
 
 - Do not list connector-heavy plugins for Codex by adding manifests only.
-- Keep the current MCP configuration as the default source of truth.
-- For HTTP MCP servers, verify Codex runtime support, auth setup, and side
-  effects before listing the owning plugin.
+- Treat CLI-backed integrations as the default source of truth when a maintained
+  CLI exists and can safely perform the workflow.
+- For HTTP MCP servers, verify runtime support, auth setup, and side effects
+  before listing the owning plugin.
 - For local npm MCP servers, verify package name, package manager/lockfile,
   environment variables, and startup behavior before deciding whether the plugin
   is public or personal/local.
-- For Google and Microsoft endpoints, call out any proposed native Codex
-  connector substitution in a GitHub issue before changing the migration plan.
+- For Microsoft endpoints, call out any proposed native Codex connector
+  substitution in a GitHub issue before changing the migration plan.
+- For Gmail, Google Calendar, and Google Drive in Claude or Codex, use the
+  `google-workspace` plugin and `gws` CLI over MCP. Open an issue only if a
+  workflow cannot be represented safely through the CLI.

--- a/data/CONNECTORS.md
+++ b/data/CONNECTORS.md
@@ -2,9 +2,15 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, notebook, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, notebook, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. Use MCP when no usable CLI exists, the CLI cannot express the
+operation safely, or the workflow depends on MCP-only capabilities.
 
 ## Connectors for this plugin
 

--- a/design/.mcp.json
+++ b/design/.mcp.json
@@ -27,14 +27,6 @@
     "intercom": {
       "type": "http",
       "url": "https://mcp.intercom.com/mcp"
-    },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
     }
   }
 }

--- a/design/CONNECTORS.md
+++ b/design/CONNECTORS.md
@@ -2,9 +2,17 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~design tool` might mean Figma, Sketch, or any other design tool with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~design tool` might mean Figma, Sketch, or any other design tool with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (design tool, project tracker, user feedback, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (design tool, project tracker, user feedback, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. If a design workflow needs Google-backed email, calendar, or files,
+use the `google-workspace` plugin and `gws` CLI after checking
+`gws auth status`. Use MCP when no usable CLI exists, the CLI cannot express the
+operation safely, or the workflow depends on MCP-only capabilities.
 
 ## Connectors for this plugin
 

--- a/engineering/.mcp.codex.json
+++ b/engineering/.mcp.codex.json
@@ -20,10 +20,6 @@
       "type": "http",
       "url": "https://mcp.notion.com/mcp"
     },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    },
     "pagerduty": {
       "type": "http",
       "url": "https://mcp.pagerduty.com/mcp"

--- a/engineering/.mcp.json
+++ b/engineering/.mcp.json
@@ -20,10 +20,6 @@
       "type": "http",
       "url": "https://mcp.notion.com/mcp"
     },
-    "github": {
-      "type": "http",
-      "url": "https://api.github.com/mcp"
-    },
     "pagerduty": {
       "type": "http",
       "url": "https://mcp.pagerduty.com/mcp"
@@ -31,14 +27,6 @@
     "datadog": {
       "type": "http",
       "url": "https://mcp.datadoghq.com/mcp"
-    },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
     }
   }
 }

--- a/engineering/CONNECTORS.md
+++ b/engineering/CONNECTORS.md
@@ -2,16 +2,24 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~source control` might mean GitHub, GitLab, or any other VCS with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~source control` might mean GitHub, GitLab, or any other VCS with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (source control, CI/CD, monitoring, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (source control, CI/CD, monitoring, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. If an engineering workflow needs Google-backed email, calendar, or
+files, use the `google-workspace` plugin and `gws` CLI after checking
+`gws auth status`. Use MCP when no usable CLI exists, the CLI cannot express the
+operation safely, or the workflow depends on MCP-only capabilities.
 
 ## Connectors for this plugin
 
 | Category | Placeholder | Included servers | Other options |
 |----------|-------------|-----------------|---------------|
 | Chat | `~~chat` | Slack | Microsoft Teams |
-| Source control | `~~source control` | GitHub | GitLab, Bitbucket |
+| Source control | `~~source control` | GitHub via `gh` CLI | GitLab, Bitbucket |
 | Project tracker | `~~project tracker` | Linear, Asana, Atlassian (Jira/Confluence) | Shortcut, ClickUp |
 | Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
 | Monitoring | `~~monitoring` | Datadog | New Relic, Grafana, Splunk |

--- a/engineering/README.md
+++ b/engineering/README.md
@@ -99,7 +99,7 @@ Every command and skill works without any integrations:
 | Incident response | Describe the incident | Monitoring, Incident management, Chat |
 | Deploy checklists | Describe the deploy | CI/CD, Source control |
 
-## MCP Integrations
+## Integrations
 
 > If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](CONNECTORS.md).
 
@@ -107,7 +107,7 @@ Connect your tools for a richer experience:
 
 | Category | Examples | What It Enables |
 |---|---|---|
-| **Source control** | GitHub, GitLab | PR diffs, commit history, branch status |
+| **Source control** | GitHub via `gh` CLI, GitLab | PR diffs, commit history, branch status |
 | **Project tracker** | Linear, Jira, Asana | Ticket status, sprint data, assignments |
 | **Monitoring** | Datadog, New Relic | Logs, metrics, alerts, dashboards |
 | **Incident management** | PagerDuty, Opsgenie | On-call schedules, incident tracking, paging |

--- a/engineering/skills/debug/SKILL.md
+++ b/engineering/skills/debug/SKILL.md
@@ -84,6 +84,7 @@ If **~~monitoring** is connected:
 If **~~source control** is connected:
 - Identify recent commits and PRs that touched affected code paths
 - Check if the issue correlates with a specific change
+- For GitHub, use the `gh` CLI before GitHub MCP.
 
 If **~~project tracker** is connected:
 - Search for related bug reports or known issues

--- a/engineering/skills/deploy-checklist/SKILL.md
+++ b/engineering/skills/deploy-checklist/SKILL.md
@@ -63,6 +63,7 @@ Tell me about your deploy and I'll customize the checklist:
 If **~~source control** is connected:
 - Pull the release diff and list of changes
 - Verify all PRs are approved and merged
+- For GitHub, use the `gh` CLI before GitHub MCP.
 
 If **~~CI/CD** is connected:
 - Check build and test status automatically

--- a/engineering/skills/review/SKILL.md
+++ b/engineering/skills/review/SKILL.md
@@ -82,6 +82,7 @@ I check for:
 If **~~source control** is connected:
 - Pull the PR diff automatically from the URL
 - Check CI status and test results
+- For GitHub, use the `gh` CLI before GitHub MCP.
 
 If **~~project tracker** is connected:
 - Link findings to related tickets

--- a/engineering/skills/standup/SKILL.md
+++ b/engineering/skills/standup/SKILL.md
@@ -60,6 +60,7 @@ If your tools are connected, just say `/engineering:standup` and I'll gather eve
 If **~~source control** is connected:
 - Pull recent commits and PRs (opened, reviewed, merged)
 - Summarize code changes at a high level
+- For GitHub, use the `gh` CLI before GitHub MCP.
 
 If **~~project tracker** is connected:
 - Pull tickets moved to "in progress" or "done"

--- a/enterprise-search/.mcp.json
+++ b/enterprise-search/.mcp.json
@@ -23,14 +23,6 @@
     "ms365": {
       "type": "http",
       "url": "https://microsoft365.mcp.claude.com/mcp"
-    },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
     }
   }
 }

--- a/enterprise-search/CONNECTORS.md
+++ b/enterprise-search/CONNECTORS.md
@@ -2,9 +2,17 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~chat` might mean Slack, Microsoft Teams, or any other chat tool with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~chat` might mean Slack, Microsoft Teams, or any other chat tool with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, email, cloud storage, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, email, cloud storage, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. When `~~email`, `~~calendar`, or `~~cloud storage` means Google
+Workspace, use the `google-workspace` plugin and `gws` CLI after checking
+`gws auth status`. Use MCP when no usable CLI exists, the CLI cannot express the
+operation safely, or the workflow depends on MCP-only capabilities.
 
 This plugin uses `~~category` references extensively as source labels in search output (e.g. `~~chat:`, `~~email:`). These are intentional — they represent dynamic category markers that resolve to whatever tool is connected.
 
@@ -18,4 +26,4 @@ This plugin uses `~~category` references extensively as source labels in search 
 | Knowledge base | `~~knowledge base` | Notion, Guru | Confluence, Slite |
 | Project tracker | `~~project tracker` | Atlassian (Jira/Confluence), Asana | Linear, monday.com |
 | CRM | `~~CRM` | *(not pre-configured)* | Salesforce, HubSpot |
-| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace via `gws` CLI |

--- a/enterprise-search/skills/digest/SKILL.md
+++ b/enterprise-search/skills/digest/SKILL.md
@@ -27,7 +27,9 @@ The user may also specify a custom range:
 
 ### 2. Check Available Sources
 
-Identify which MCP sources are connected (same approach as the search command):
+Identify which sources are connected (same approach as the search command).
+Prefer a maintained CLI over MCP when the CLI can safely perform the workflow;
+for Google Workspace, check whether `gws auth status` succeeds:
 
 - **~~chat** — channels, DMs, mentions
 - **~~email** — inbox, sent, threads
@@ -39,7 +41,9 @@ Identify which MCP sources are connected (same approach as the search command):
 If no sources are connected, guide the user:
 ```
 To generate a digest, you'll need at least one source connected.
-Check your MCP settings to add ~~chat, ~~email, ~~cloud storage, or other tools.
+Use a maintained CLI when available, or add MCP sources for services without a
+safe CLI path. For Google Workspace, authenticate the `gws` CLI instead of
+adding Gmail, Google Calendar, or Google Drive MCP.
 ```
 
 ### 3. Gather Activity from Each Source
@@ -54,10 +58,13 @@ Check your MCP settings to add ~~chat, ~~email, ~~cloud storage, or other tools.
 - Search recent inbox messages
 - Identify threads with new replies
 - Flag emails with action items or questions directed at the user
+- If the email source is Gmail, use `gws gmail` commands instead of Gmail MCP.
 
 **~~cloud storage:**
 - Find documents recently modified or shared with the user
 - Note new comments on docs the user owns or collaborates on
+- If the file source is Google Drive, use `gws drive` and `gws docs` commands
+  instead of Google Drive MCP.
 
 **~~project tracker:**
 - Tasks assigned to the user (new or updated)

--- a/enterprise-search/skills/search/SKILL.md
+++ b/enterprise-search/skills/search/SKILL.md
@@ -9,13 +9,16 @@ disable-model-invocation: true
 
 > If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
 
-Search across all connected MCP sources in a single query. Decompose the user's question, run parallel searches, and synthesize results.
+Search across all connected sources in a single query. Decompose the user's question, run parallel searches, and synthesize results.
 
 ## Instructions
 
 ### 1. Check Available Sources
 
-Before searching, determine which MCP sources are available. Attempt to identify connected tools from the available tool list. Common sources:
+Before searching, determine which connected sources are available. Prefer a
+maintained CLI over MCP when the CLI can safely perform the workflow; for
+Google Workspace, check whether `gws auth status` succeeds. Attempt to identify
+connected tools from the available tool list. Common sources:
 
 - **~~chat** — chat platform tools
 - **~~email** — email tools
@@ -24,13 +27,15 @@ Before searching, determine which MCP sources are available. Attempt to identify
 - **~~CRM** — CRM tools
 - **~~knowledge base** — knowledge base tools
 
-If no MCP sources are connected:
+If no sources are connected:
 ```
 To search across your tools, you'll need to connect at least one source.
-Check your MCP settings to add ~~chat, ~~email, ~~cloud storage, or other tools.
+Use a maintained CLI when available, or add MCP sources for services without a
+safe CLI path. For Google Workspace, authenticate the `gws` CLI instead of
+adding Gmail, Google Calendar, or Google Drive MCP.
 
 Supported sources: ~~chat, ~~email, ~~cloud storage, ~~project tracker, ~~CRM, ~~knowledge base,
-and any other MCP-connected service.
+and any other connected service.
 ```
 
 ### 2. Parse the User's Query
@@ -62,11 +67,14 @@ For each available source, create a targeted sub-query using that source's nativ
 - Use available email search tools
 - Translate filters: `from:` maps to sender, dates map to time range filters
 - Map `type:` to attachment filters or subject-line searches as appropriate
+- If the email source is Gmail, use `gws gmail` commands instead of Gmail MCP.
 
 **~~cloud storage:**
 - Use available file search tools
 - Translate to file query syntax: name contains, full text contains, modified date, file type
 - Consider both file names and content
+- If the file source is Google Drive, use `gws drive` and `gws docs` commands
+  instead of Google Drive MCP.
 
 **~~project tracker:**
 - Use available task search or typeahead tools

--- a/enterprise-search/skills/source-management/SKILL.md
+++ b/enterprise-search/skills/source-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: source-management
-description: Manages connected MCP sources for enterprise search. Detects available sources, guides users to connect new ones, handles source priority ordering, and manages rate limiting awareness.
+description: Manages connected sources for enterprise search. Detects available sources, guides users to connect new ones, handles source priority ordering, and manages rate limiting awareness.
 ---
 
 # Source Management
@@ -11,7 +11,11 @@ Knows what sources are available, helps connect new ones, and manages how source
 
 ## Checking Available Sources
 
-Determine which MCP sources are connected by checking available tools. Each source corresponds to a set of MCP tools:
+Determine which sources are connected by checking available tools and known
+CLIs. Prefer a maintained CLI over MCP when the CLI can safely perform the
+workflow. For Google Workspace, also check whether `gws auth status` succeeds;
+Gmail, Google Calendar, and Google Drive should use the `gws` CLI rather than
+MCP. Each source corresponds to a set of tools:
 
 | Source | Key capabilities |
 |--------|-----------------|
@@ -31,7 +35,8 @@ When a user searches but has few or no sources connected:
 ```
 You currently have [N] source(s) connected: [list].
 
-To expand your search, you can connect additional sources in your MCP settings:
+To expand your search, connect maintained CLIs first where available, then add
+MCP sources for services without a safe CLI path:
 - ~~chat — messages, threads, channels
 - ~~email — emails, conversations, attachments
 - ~~cloud storage — docs, sheets, slides
@@ -40,9 +45,14 @@ To expand your search, you can connect additional sources in your MCP settings:
 - ~~knowledge base — wiki pages, knowledge base articles
 
 The more sources you connect, the more complete your search results.
+
+For Gmail, Google Calendar, or Google Drive, use the `google-workspace` plugin
+and authenticate with `gws auth login`; do not add Google Workspace MCP unless a
+workflow cannot be represented safely through the CLI.
 ```
 
-When a user asks about a specific tool that is not connected:
+When a user asks about a specific non-Google tool that is not connected and no
+maintained CLI path is available:
 
 ```
 [Tool name] isn't currently connected. To add it:
@@ -51,6 +61,14 @@ When a user asks about a specific tool that is not connected:
 3. Authenticate when prompted
 
 Once connected, it will be automatically included in future searches.
+```
+
+When the missing tool is Gmail, Google Calendar, or Google Drive:
+
+```
+Google Workspace should use the `gws` CLI here. Run `gws auth status` to check
+auth, or `gws auth login` to authenticate before searching Gmail, Calendar, or
+Drive.
 ```
 
 ## Source Priority Ordering
@@ -117,7 +135,7 @@ When query type is unclear:
 
 ## Rate Limiting Awareness
 
-MCP sources may have rate limits. Handle them gracefully:
+CLI and MCP sources may have rate limits. Handle them gracefully:
 
 ### Detection
 
@@ -164,7 +182,11 @@ When reporting search results, include which sources were searched so the user k
 
 ## Adding Custom Sources
 
-The enterprise search plugin works with any MCP-connected source. As new MCP servers become available, they can be added to the `.mcp.json` configuration. The search and digest commands will automatically detect and include new sources based on available tools.
+The enterprise search plugin works with CLI-connected sources first, then with
+MCP-connected sources where no safe CLI path exists. It uses the `gws` CLI for
+Google Workspace. As new non-Google MCP servers become available, they can be
+added to the `.mcp.json` configuration. The search and digest commands will
+automatically detect and include new sources based on available tools.
 
 To add a new source:
 1. Add the MCP server configuration to `.mcp.json`

--- a/finance/.mcp.json
+++ b/finance/.mcp.json
@@ -11,14 +11,6 @@
     "ms365": {
       "type": "http",
       "url": "https://microsoft365.mcp.claude.com/mcp"
-    },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
     }
   }
 }

--- a/finance/CONNECTORS.md
+++ b/finance/CONNECTORS.md
@@ -2,9 +2,17 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~data warehouse` might mean Snowflake, BigQuery, or any other warehouse with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, chat, project tracker, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (data warehouse, chat, project tracker, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. If a finance workflow needs Google-backed email, calendar, Sheets,
+Docs, or Drive files, use the `google-workspace` plugin and `gws` CLI after
+checking `gws auth status`. Use MCP when no usable CLI exists, the CLI cannot
+express the operation safely, or the workflow depends on MCP-only capabilities.
 
 ## Connectors for this plugin
 

--- a/legal/.mcp.json
+++ b/legal/.mcp.json
@@ -4,14 +4,6 @@
       "type": "http",
       "url": "https://mcp.slack.com/mcp"
     },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
-    },
     "docusign": {
       "type": "http",
       "url": "https://mcp.docusign.com/mcp"
@@ -23,10 +15,6 @@
     "notion": {
       "type": "http",
       "url": "https://mcp.notion.com/mcp"
-    },
-    "google-drive": {
-      "type": "http",
-      "url": "https://google-drive-mcp.claude.com/mcp"
     }
   }
 }

--- a/legal/CONNECTORS.md
+++ b/legal/CONNECTORS.md
@@ -2,19 +2,27 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~e-signature` might mean DocuSign, Adobe Sign, or any other e-signature system with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~e-signature` might mean DocuSign, Adobe Sign, or any other e-signature system with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (contract storage, CRM, e-signature, etc.) rather than a specific organization's stack. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (contract storage, CRM, e-signature, etc.) rather than a specific organization's stack. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. Use `gws gmail`, `gws calendar`, `gws drive`, or `gws docs` for Google
+Workspace after checking `gws auth status`. Use MCP when no usable CLI exists,
+the CLI cannot express the operation safely, or the workflow depends on
+MCP-only capabilities.
 
 ## Connectors for this plugin
 
 | Category | Placeholder | Included servers | Other options |
 |----------|-------------|-----------------|---------------|
-| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Calendar | `~~calendar` | Google Calendar via `gws` CLI | Microsoft 365 |
 | Chat | `~~chat` | Slack | Microsoft Teams |
-| Cloud storage | `~~cloud storage` | Google Drive | Microsoft 365, Box, Dropbox, Egnyte |
+| Cloud storage | `~~cloud storage` | Google Drive via `gws` CLI | Microsoft 365, Box, Dropbox, Egnyte |
 | CRM | `~~CRM` | HubSpot | Salesforce, Pipedrive |
-| Email | `~~email` | Gmail | Microsoft 365 |
+| Email | `~~email` | Gmail via `gws` CLI | Microsoft 365 |
 | E-signature | `~~e-signature` | DocuSign | Adobe Sign, PandaDoc |
 | Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
 

--- a/legal/skills/signature-request/SKILL.md
+++ b/legal/skills/signature-request/SKILL.md
@@ -30,6 +30,9 @@ Accept the document in any format:
 - **URL**: Link to a document in Google Drive or PandaDoc
 - **Reference**: "The Acme Corp MSA we finalized yesterday"
 
+Use `gws drive` and `gws docs` for Google Drive/Docs documents rather than
+Google Drive MCP.
+
 ### Step 2: Pre-Signature Checklist
 
 Before routing for signature, verify:
@@ -102,4 +105,4 @@ Gather signing details:
 
 1. **Check entity names carefully** — The most common signing error is incorrect legal entity names.
 2. **Verify authority** — Make sure each signer is authorized to bind their organization.
-3. **Keep a copy** — Executed copies should be filed in Google Drive immediately after execution.
+3. **Keep a copy** — Executed copies should be filed in Google Drive immediately after execution. Use `gws drive` for this Google-backed filing step.

--- a/operations/.mcp.json
+++ b/operations/.mcp.json
@@ -4,14 +4,6 @@
       "type": "http",
       "url": "https://mcp.slack.com/mcp"
     },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
-    },
     "notion": {
       "type": "http",
       "url": "https://mcp.notion.com/mcp"

--- a/operations/CONNECTORS.md
+++ b/operations/CONNECTORS.md
@@ -2,19 +2,27 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~ITSM` might mean ServiceNow, Zendesk, or any other service management tool with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~ITSM` might mean ServiceNow, Zendesk, or any other service management tool with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (ITSM, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (ITSM, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. Use `gws gmail`, `gws calendar`, `gws drive`, or `gws docs` for Google
+Workspace after checking `gws auth status`. Use MCP when no usable CLI exists,
+the CLI cannot express the operation safely, or the workflow depends on
+MCP-only capabilities.
 
 ## Connectors for this plugin
 
 | Category | Placeholder | Included servers | Other options |
 |----------|-------------|-----------------|---------------|
-| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Calendar | `~~calendar` | Google Calendar via `gws` CLI | Microsoft 365 |
 | Chat | `~~chat` | Slack | Microsoft Teams |
-| Email | `~~email` | Gmail, Microsoft 365 | — |
+| Email | `~~email` | Gmail via `gws` CLI, Microsoft 365 | — |
 | ITSM | `~~ITSM` | ServiceNow | Zendesk, Freshservice, Jira Service Management |
 | Knowledge base | `~~knowledge base` | Notion, Atlassian (Confluence) | Guru, Coda |
 | Project tracker | `~~project tracker` | Asana, Atlassian (Jira) | Linear, monday.com, ClickUp |
 | Procurement | `~~procurement` | — | Coupa, SAP Ariba, Zip |
-| Office suite | `~~office suite` | Microsoft 365 | Google Workspace |
+| Office suite | `~~office suite` | Microsoft 365 | Google Workspace via `gws` CLI |

--- a/operations/skills/capacity-plan/SKILL.md
+++ b/operations/skills/capacity-plan/SKILL.md
@@ -71,6 +71,7 @@ If **~~project tracker** is connected:
 If **~~calendar** is connected:
 - Factor in PTO, holidays, and recurring meeting load
 - Calculate actual available hours per person
+- Use `gws calendar` for Google Calendar rather than Google Calendar MCP.
 
 ## Tips
 

--- a/operations/skills/status-report/SKILL.md
+++ b/operations/skills/status-report/SKILL.md
@@ -70,6 +70,7 @@ If **~~chat** is connected:
 
 If **~~calendar** is connected:
 - Reference key meetings and decisions from the reporting period
+- Use `gws calendar` for Google Calendar rather than Google Calendar MCP.
 
 ## Tips
 

--- a/product-management/.mcp.json
+++ b/product-management/.mcp.json
@@ -48,14 +48,6 @@
       "type": "http",
       "url": "https://api.fireflies.ai/mcp"
     },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
-    },
     "similarweb": {
       "type": "http",
       "url": "https://mcp.similarweb.com/mcp"

--- a/product-management/CONNECTORS.md
+++ b/product-management/CONNECTORS.md
@@ -2,19 +2,27 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Linear, Asana, Jira, or any other tracker with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Linear, Asana, Jira, or any other tracker with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (project tracker, design, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (project tracker, design, product analytics, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. Use `gws gmail`, `gws calendar`, `gws drive`, or `gws docs` for Google
+Workspace after checking `gws auth status`. Use MCP when no usable CLI exists,
+the CLI cannot express the operation safely, or the workflow depends on
+MCP-only capabilities.
 
 ## Connectors for this plugin
 
 | Category | Placeholder | Included servers | Other options |
 |----------|-------------|-----------------|---------------|
-| Calendar | `~~calendar` | Google Calendar | Microsoft 365 |
+| Calendar | `~~calendar` | Google Calendar via `gws` CLI | Microsoft 365 |
 | Chat | `~~chat` | Slack | Microsoft Teams |
 | Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
 | Design | `~~design` | Figma | Sketch, Adobe XD |
-| Email | `~~email` | Gmail | Microsoft 365 |
+| Email | `~~email` | Gmail via `gws` CLI | Microsoft 365 |
 | Knowledge base | `~~knowledge base` | Notion | Confluence, Guru, Coda |
 | Meeting transcription | `~~meeting transcription` | Fireflies | Gong, Dovetail, Otter.ai |
 | Product analytics | `~~product analytics` | Amplitude, Pendo | Mixpanel, Heap, FullStory |

--- a/productivity/.mcp.json
+++ b/productivity/.mcp.json
@@ -31,14 +31,6 @@
     "clickup": {
       "type": "http",
       "url": "https://mcp.clickup.com/mcp"
-    },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
     }
   }
 }

--- a/productivity/CONNECTORS.md
+++ b/productivity/CONNECTORS.md
@@ -2,9 +2,17 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Asana, Linear, Jira, or any other project tracker with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~project tracker` might mean Asana, Linear, Jira, or any other project tracker with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (chat, project tracker, knowledge base, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. Use `gws gmail`, `gws calendar`, `gws drive`, or `gws docs` for Google
+Workspace after checking `gws auth status`. Use MCP when no usable CLI exists,
+the CLI cannot express the operation safely, or the workflow depends on
+MCP-only capabilities.
 
 ## Connectors for this plugin
 

--- a/productivity/skills/start/SKILL.md
+++ b/productivity/skills/start/SKILL.md
@@ -93,11 +93,16 @@ Or we can stick with what we have and add context later.
 
 **If they choose comprehensive scan:**
 
-Gather data from available MCP sources:
+Gather data from available connected sources. Prefer a maintained CLI over MCP
+when the CLI can safely perform the workflow; for Google Workspace, use the
+`gws` CLI:
 - **Chat:** Recent messages, channels, DMs
-- **Email:** Sent messages, recipients
-- **Documents:** Recent docs, collaborators
-- **Calendar:** Meetings, attendees
+- **Email:** Sent messages, recipients. For Gmail, use `gws gmail` instead of
+  Gmail MCP.
+- **Documents:** Recent docs, collaborators. For Google Drive/Docs, use
+  `gws drive` and `gws docs` instead of Google Drive MCP.
+- **Calendar:** Meetings, attendees. For Google Calendar, use `gws calendar`
+  instead of Google Calendar MCP.
 
 Build a braindump of people, projects, and terms found. Present findings grouped by confidence:
 - **Ready to add** (high confidence) — offer to add directly

--- a/productivity/skills/update/SKILL.md
+++ b/productivity/skills/update/SKILL.md
@@ -108,11 +108,16 @@ Everything in Default Mode, plus a deep scan of recent activity.
 
 ### Extra Step: Scan Activity Sources
 
-Gather data from available MCP sources:
+Gather data from available connected sources. Prefer a maintained CLI over MCP
+when the CLI can safely perform the workflow; for Google Workspace, use the
+`gws` CLI:
 - **Chat:** Search recent messages, read active channels
-- **Email:** Search sent messages
-- **Documents:** List recently touched docs
-- **Calendar:** List recent + upcoming events
+- **Email:** Search sent messages. For Gmail, use `gws gmail` instead of Gmail
+  MCP.
+- **Documents:** List recently touched docs. For Google Drive/Docs, use
+  `gws drive` and `gws docs` instead of Google Drive MCP.
+- **Calendar:** List recent + upcoming events. For Google Calendar, use
+  `gws calendar` instead of Google Calendar MCP.
 
 ### Extra Step: Flag Missed Todos
 

--- a/sales/.mcp.json
+++ b/sales/.mcp.json
@@ -44,14 +44,6 @@
       "type": "http",
       "url": "https://mcp.outreach.io/mcp"
     },
-    "google-calendar": {
-      "type": "http",
-      "url": "https://gcal.mcp.claude.com/mcp"
-    },
-    "gmail": {
-      "type": "http",
-      "url": "https://gmail.mcp.claude.com/mcp"
-    },
     "similarweb": {
       "type": "http",
       "url": "https://mcp.similarweb.com/mcp"

--- a/sales/CONNECTORS.md
+++ b/sales/CONNECTORS.md
@@ -2,20 +2,28 @@
 
 ## How tool references work
 
-Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~CRM` might mean Salesforce, HubSpot, or any other CRM with an MCP server.
+Plugin files use `~~category` as a placeholder for whatever tool the user connects in that category. For example, `~~CRM` might mean Salesforce, HubSpot, or any other CRM with a CLI or MCP source.
 
-Plugins are **tool-agnostic** — they describe workflows in terms of categories (CRM, chat, email, etc.) rather than specific products. The `.mcp.json` pre-configures specific MCP servers, but any MCP server in that category works.
+Plugins are **tool-agnostic** — they describe workflows in terms of categories (CRM, chat, email, etc.) rather than specific products. The `.mcp.json` pre-configures fallback MCP servers, but any maintained CLI or MCP source in that category works when it follows the CLI-first policy below.
+
+## CLI-first integration policy
+
+Prefer a maintained CLI over MCP whenever the CLI can safely perform the
+workflow. Use `gws gmail`, `gws calendar`, `gws drive`, or `gws docs` for Google
+Workspace after checking `gws auth status`. Use MCP when no usable CLI exists,
+the CLI cannot express the operation safely, or the workflow depends on
+MCP-only capabilities.
 
 ## Connectors for this plugin
 
 | Category | Placeholder | Included servers | Other options |
 |----------|-------------|-----------------|---------------|
-| Calendar | `~~calendar` | Google Calendar, Microsoft 365 | — |
+| Calendar | `~~calendar` | Google Calendar via `gws` CLI, Microsoft 365 | — |
 | Chat | `~~chat` | Slack | Microsoft Teams |
 | Competitive intelligence | `~~competitive intelligence` | Similarweb | Crayon, Klue |
 | CRM | `~~CRM` | HubSpot, Close | Salesforce, Pipedrive, Copper |
 | Data enrichment | `~~data enrichment` | Clay, ZoomInfo, Apollo | Clearbit, Lusha |
-| Email | `~~email` | Gmail, Microsoft 365 | — |
+| Email | `~~email` | Gmail via `gws` CLI, Microsoft 365 | — |
 | Knowledge base | `~~knowledge base` | Notion | Confluence, Guru |
 | Meeting transcription | `~~conversation intelligence` | Fireflies | Gong, Chorus, Otter.ai |
 | Project tracker | `~~project tracker` | Atlassian (Jira/Confluence) | Linear, Asana |

--- a/sales/skills/call-summary/SKILL.md
+++ b/sales/skills/call-summary/SKILL.md
@@ -158,6 +158,8 @@ Here's what we discussed:
 **Email connected:**
 - I'll offer to create a draft in ~~email
 - Or send directly if you approve
+- Use `gws gmail` for Gmail delivery rather than Gmail MCP, and use `--dry-run`
+  or show the exact message before sending.
 
 ---
 

--- a/sales/skills/draft-outreach/SKILL.md
+++ b/sales/skills/draft-outreach/SKILL.md
@@ -16,6 +16,8 @@ Research first, then draft. This skill never sends generic outreach - it always 
 | **Email** | Create draft directly in your inbox |
 
 > **No connectors?** Web research works great. I'll output the email text for you to copy.
+> For Gmail, use the `google-workspace` plugin and `gws gmail` CLI rather than
+> Gmail MCP, and show the draft or use `--dry-run` before sending.
 
 ---
 


### PR DESCRIPTION
## Summary
- make CLI-backed integrations the default preference for Claude and Codex when a maintained CLI can safely perform the workflow
- remove Gmail, Google Calendar, Google Drive, and GitHub MCP entries from domain-pack MCP configs in favor of `gws` and `gh`
- update connector docs and workflow skills to route Google Workspace and GitHub work through CLI-backed paths

## Validation
- ruby scripts/validate_repo.rb
- git diff --check
- rg -n "gmail\.mcp|gcal\.mcp|google-drive-mcp|api\.github.*mcp|githubcopilot.*mcp" --glob ".mcp*.json"