### PR TITLE
Tighten CLI pilot validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,10 @@ Not every plugin uses all component types.
 - Route BigQuery, Guru, Context7, and Cloudflare through their maintained CLIs
   rather than default MCP. Pilot Hex, Notion, and ServiceNow CLI workflows, but
   keep their MCP configs until auth, JSON output, write safeguards, and workflow
-  coverage are validated.
+  coverage are validated. For ServiceNow, `snc` means the official
+  ServiceNow Store/GitHub client; npm `snc` is unrelated and
+  `@servicenow/cli` / `now-cli` is an app-development surface, not the generic
+  ITSM record replacement.
 - Use `ruby scripts/check_cli_integrations.rb` to report local CLI availability
   for CLI-backed replacements. The script does not install anything; use
   `--strict` only when validating an environment expected to have the required

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,10 @@ Not every plugin uses all component types.
 - Route BigQuery, Guru, Context7, and Cloudflare through their maintained CLIs
   rather than default MCP. Pilot Hex, Notion, and ServiceNow CLI workflows, but
   keep their MCP configs until auth, JSON output, write safeguards, and workflow
-  coverage are validated.
+  coverage are validated. For ServiceNow, `snc` means the official
+  ServiceNow Store/GitHub client; npm `snc` is unrelated and
+  `@servicenow/cli` / `now-cli` is an app-development surface, not the generic
+  ITSM record replacement.
 - Use `ruby scripts/check_cli_integrations.rb` to report local CLI availability
   for CLI-backed replacements. The script does not install anything; use
   `--strict` only when validating an environment expected to have the required

--- a/DOMAIN_PACKS_CODEX.md
+++ b/DOMAIN_PACKS_CODEX.md
@@ -89,8 +89,14 @@ Remaining omitted endpoints have these final dispositions:
   not resolve and ServiceNow documents instance-generated server URLs of the
   form
   `https://<instance>.service-now.com/sncapps/mcp-server/mcp/<server-name>`.
-  Claude retains the existing config pending the `snc` CLI pilot.
+  Claude retains the existing config pending the official ServiceNow `snc`
+  client pilot. Do not treat the unrelated npm package named `snc` or the
+  app-development `@servicenow/cli` / `now-cli` package as this replacement.
 
 Pilot CLI candidates are tracked in [MCP_CLI_REVIEW.md](MCP_CLI_REVIEW.md).
 Do not remove `hex`, `notion`, or `servicenow` MCP configs solely because a CLI
-exists; their CLI paths still need smoke tests and workflow coverage mapping.
+exists; their CLI paths still need authenticated smoke tests and workflow
+coverage mapping. Hex still needs MCP for Agent thread create/continue,
+Notion still needs MCP for Notion AI search and database-view workflows, and
+ServiceNow still needs MCP for instance-specific MCP servers or server-side
+workflows outside generic record operations.

--- a/MCP_CLI_REVIEW.md
+++ b/MCP_CLI_REVIEW.md
@@ -29,9 +29,9 @@ inspection, write safeguards, and the concrete workflows used by the plugin.
 | `fireflies` | Pilot | `ffcli`, GraphQL API | Pilot read-only transcript workflows; keep MCP for management/soundbite/channel workflows. |
 | `hubspot` | Pilot | community `hubspot-cli`, `g-gremlin`; official `hs` only for dev/CMS | Pilot CRM operations; do not treat official `hs` as CRM replacement. |
 | `intercom` | Pilot | official `@intercom/cli`, OpenAPI | Strong pilot candidate; likely replace after auth/read/write smoke tests. |
-| `hex` | Pilot | official `hex` CLI | Keep MCP for Hex Agent thread workflows until CLI coverage is confirmed. |
-| `notion` | Pilot | official `ntn` CLI | Keep MCP until Notion AI search/tool coverage is mapped; pilot page/data-source/file workflows. |
-| `servicenow` | Pilot | official `snc` CLI | Pilot generic ITSM table CRUD; keep MCP for Now Assist or instance-specific workflows. |
+| `hex` | Pilot | official `hex` CLI | Pilot workspace/project/cell/run/connection inventory and controlled draft operations. Keep MCP for Agent thread create/continue and natural-language exploration workflows. |
+| `notion` | Pilot | official `ntn` CLI | Pilot page, data-source, file, and raw API workflows. Keep MCP for Notion AI search, connected-source search, and database-view workflows. |
+| `servicenow` | Pilot | official `snc` CLI | Pilot generic record query/get/create/update/delete only with the ServiceNow `snc` client. Keep MCP for instance-specific MCP servers and Now Assist-style workflows. |
 | `asana` | Wrapper candidate | Asana REST/API client wrapper; community CLIs are partial | Build/pilot wrapper only if broad Work Graph workflows are needed without MCP. |
 | `monday` | Wrapper candidate | GraphQL API wrapper; official `mapps` is app-dev only | Build wrapper for board/item/docs workflows before removing MCP. |
 | `slack` | Wrapper candidate | Slack Web API wrapper; official Slack CLI is app-dev only | Do not use browser-token CLIs. Keep MCP until scoped Web API wrapper exists. |
@@ -55,6 +55,59 @@ Before moving any `Pilot` vendor to "replace now":
 5. Verify JSON or NDJSON output that an agent can parse safely.
 6. Verify dry-run, preview, or confirmation boundaries for writes.
 7. Update both Claude and Codex configs in the same direction unless a documented runtime limitation prevents parity.
+
+`ruby scripts/check_cli_integrations.rb` is a local availability check, not an
+installer. For ambiguous command names, it verifies the binary identity before
+reporting an installed command so unrelated packages such as npm `hex` or npm
+`snc` are not accepted by accident.
+
+## Pilot Findings
+
+### Hex
+
+The official Hex CLI is a useful pilot, but it is not a full MCP replacement
+yet. Official install paths are `brew install hex-inc/hex-cli/hex` or the Hex
+install script; do not use the unrelated npm package named `hex`. Use
+`hex --json ...` for agent-readable output and `hex auth status` before live
+workflows.
+
+Good CLI pilot workflows are read-heavy workspace inspection and bounded
+operations such as `hex --json project list`, `hex --json project get`,
+`hex --json project export`, `hex --json cell list`, `hex --json connection
+list`, and run status checks. The MCP still carries Hex Agent Thread workflows:
+project semantic search, `create_thread`, `get_thread`, and
+`continue_thread`, including generated charts/tables and follow-up analysis.
+
+### Notion
+
+The official Notion CLI is a strong pilot for page, data-source, file, and raw
+API workflows. Official install paths are `curl -fsSL https://ntn.dev | bash`
+or `npm install --global ntn`; Node.js 22+ and npm 10+ are required for the npm
+path. Use `ntn doctor` for setup/auth health and prefer JSON-capable commands
+such as `ntn api ls --json`, `ntn pages get <page-id> --json`, and
+`ntn datasources query <data-source-id> --filter ... --json`.
+
+Keep Notion MCP until authenticated parity is proven for Notion AI search,
+connected-source search, database-view queries, and higher-level agent tools.
+The CLI is better for file upload workflows, but raw `ntn api` write calls are
+powerful and still require explicit user confirmation.
+
+### ServiceNow
+
+ServiceNow currently has two different command-line surfaces that are easy to
+confuse:
+
+- `snc` is the ServiceNow CLI documented for instance connection profiles,
+  JSON output, and record CRUD/query commands such as `snc record query`.
+- `@servicenow/cli` exposes `now-cli` and is oriented around UI/component app
+  development, not generic ITSM table workflows.
+
+Do not install or run the unrelated npm package named `snc`. Pilot ServiceNow
+CLI replacement only when the ServiceNow Store/GitHub `snc` client is available
+and `snc configure profile list --output json` plus read-only record queries
+pass against the target instance. Keep MCP for instance-generated MCP servers,
+Now Assist-style workflows, and any workflow that needs server-side tools not
+covered by generic record operations.
 
 ## Wrapper Gates
 

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -37,18 +37,18 @@ omissions, and side-effect expectations.
 | `figma` | HTTP MCP | `https://mcp.figma.com/mcp` | `design`, `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `fireflies` | HTTP MCP | `https://api.fireflies.ai/mcp` | `product-management`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `guru` | removed HTTP MCP | Previously `https://mcp.api.getguru.com/mcp` | `enterprise-search` |  | Default path is the Guru CLI (`guru` / `@getguru/cli`). Removed from Claude and Codex enterprise-search MCP configs. |
-| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Pilot the official `hex` CLI for projects/apps/cells/runs; keep MCP until Hex Agent thread workflows are mapped. |
+| `hex` | HTTP MCP | `https://app.hex.tech/mcp` | `data` |  | Pilot the official `hex` CLI for workspace/project/cell/run/connection workflows; keep MCP for Hex Agent thread create/continue workflows. |
 | `hubspot` | HTTP MCP | `https://mcp.hubspot.com/anthropic` | `legal`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `intercom` | HTTP MCP | `https://mcp.intercom.com/mcp` | `design`, `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `linear` | HTTP MCP | `https://mcp.linear.app/mcp` | `design`, `engineering`, `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `namecheap` | local npm MCP | `npx -y @grailautomation/namecheap-mcp` | `namecheap` | `NAMECHEAP_API_KEY`, `NAMECHEAP_API_USER`, `NAMECHEAP_USERNAME` | Public Claude and Codex plugin; npm package exists at `0.1.0`; published `npx` tools/list smoke passed with 8 tools |
-| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Pilot the official `ntn` CLI for page/data-source/file workflows; keep MCP until Notion AI search and plan-gated tool coverage are mapped. |
+| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Pilot the official `ntn` CLI for page/data-source/file/API workflows; keep MCP until Notion AI search, connected-source search, and database-view coverage are mapped. |
 | `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
-| `servicenow` | HTTP MCP for Claude, omitted for Codex | `https://mcp.servicenow.com/mcp` | `operations` |  | Pilot the official `snc` CLI for generic ITSM table/record workflows. Claude keeps MCP pending pilot; Codex omits the unresolved shared endpoint. |
+| `servicenow` | HTTP MCP for Claude, omitted for Codex | `https://mcp.servicenow.com/mcp` | `operations` |  | Pilot the official ServiceNow `snc` client for generic record query/get/create/update/delete workflows. Claude keeps MCP pending pilot; Codex omits the unresolved shared endpoint. Do not use npm `snc` or `@servicenow/cli` as this replacement. |
 | `similarweb` | HTTP MCP | `https://mcp.similarweb.com/mcp` | `product-management`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `slack` | HTTP MCP | `https://mcp.slack.com/mcp` | `design`, `engineering`, `enterprise-search`, `finance`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `zoominfo` | HTTP MCP | `https://mcp.zoominfo.com/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
@@ -84,17 +84,17 @@ previously succeeded.
 | `google-calendar` | Removed from domain-pack MCP configs | Use the separate `google-workspace` CLI plugin and `gws calendar` for Google Workspace work. Do not add Google Calendar MCP unless a future issue documents why CLI is insufficient. |
 | `google-drive` | Removed from domain-pack MCP configs | Use the separate `google-workspace` CLI plugin and `gws drive` for Google Workspace work. Do not add Google Drive MCP unless a future issue documents why CLI is insufficient. |
 | `guru` | Removed from domain MCP configs | Use the Guru CLI for Guru search and card workflows. Do not re-add Guru MCP unless a future issue documents why the CLI is insufficient. |
-| `hex` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; pilot the official Hex CLI before removing MCP because Hex Agent thread workflows may still require MCP. |
+| `hex` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; pilot the official Hex CLI before removing MCP because Hex Agent thread create/continue workflows still require MCP. |
 | `hubspot` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `intercom` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `linear` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `monday` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `ms365` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; Microsoft auth setup required. |
-| `notion` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; pilot the official Notion `ntn` CLI before removing MCP because Notion AI search and plan-gated tool coverage still need mapping. |
+| `notion` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; pilot the official Notion `ntn` CLI before removing MCP because Notion AI search, connected-source search, and database-view coverage still need mapping. |
 | `outreach` | Included in filtered Codex MCP configs with corrected Codex URL | Original Claude host did not resolve; Codex uses `https://api.outreach.io/mcp/`, which reached an auth challenge. Outreach Amplify/org enablement and user auth required. |
 | `pagerduty` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
 | `pendo` | Omitted from Codex filtered configs | The existing URL did not resolve from this network, and Pendo documents regional MCP URLs that must match the user's sign-in hostname; no universal public default is committed. |
-| `servicenow` | Included in Claude MCP config; omitted from Codex filtered configs | The configured shared host did not resolve for Codex, while Claude retains the existing config pending the `snc` CLI pilot. ServiceNow also documents instance-generated server URLs of the form `https://<instance>.service-now.com/sncapps/mcp-server/mcp/<server-name>`. |
+| `servicenow` | Included in Claude MCP config; omitted from Codex filtered configs | The configured shared host did not resolve for Codex, while Claude retains the existing config pending the official ServiceNow `snc` client pilot. ServiceNow also documents instance-generated server URLs of the form `https://<instance>.service-now.com/sncapps/mcp-server/mcp/<server-name>`. |
 | `similarweb` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; API key or bearer-token setup required. |
 | `slack` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token/OAuth setup required. |
 | `zoominfo` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |

--- a/data/CONNECTORS.md
+++ b/data/CONNECTORS.md
@@ -17,7 +17,7 @@ operation safely, or the workflow depends on MCP-only capabilities.
 | Category | Placeholder | Default integrations | Other options |
 |----------|-------------|-----------------|---------------|
 | Data warehouse | `~~data warehouse` | BigQuery via `bq` CLI | Snowflake, Databricks, Redshift, PostgreSQL, MySQL |
-| Notebook | `~~notebook` | Hex MCP; pilot `hex` CLI | Jupyter, Deepnote, Observable |
+| Notebook | `~~notebook` | Hex MCP; pilot official `hex` CLI for inventory/export/run workflows | Jupyter, Deepnote, Observable |
 | Product analytics | `~~product analytics` | Amplitude MCP | Mixpanel, Heap |
 | Project tracker | `~~project tracker` | Atlassian MCP (Jira/Confluence) | Linear, Asana |
 

--- a/design/CONNECTORS.md
+++ b/design/CONNECTORS.md
@@ -20,7 +20,7 @@ operation safely, or the workflow depends on MCP-only capabilities.
 |----------|-------------|-----------------|---------------|
 | Chat | `~~chat` | Slack MCP | Microsoft Teams |
 | Design tool | `~~design tool` | Figma MCP | Sketch, Adobe XD, Framer |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot | Confluence, Guru, Coda |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Confluence, Guru, Coda |
 | Project tracker | `~~project tracker` | Linear MCP, Asana MCP, Atlassian MCP (Jira/Confluence) | Shortcut, ClickUp |
 | User feedback | `~~user feedback` | Intercom MCP | Productboard, Canny, UserVoice, Dovetail |
 | Product analytics | `~~product analytics` | — | Amplitude, Mixpanel, Heap, FullStory |

--- a/design/README.md
+++ b/design/README.md
@@ -111,7 +111,7 @@ Connect your tools for a richer experience:
 | **Design tool** | Figma | Pull designs, inspect components, access design tokens |
 | **User feedback** | Intercom, Productboard | Raw feedback, feature requests, NPS data |
 | **Project tracker** | Linear, Asana, Jira | Link designs to tickets, track implementation |
-| **Knowledge base** | Notion MCP with `ntn` CLI pilot | Brand guidelines, design principles, research repository |
+| **Knowledge base** | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Brand guidelines, design principles, research repository |
 | **Product analytics** | Amplitude, Mixpanel | Usage data for research synthesis and design decisions |
 
 See [CONNECTORS.md](CONNECTORS.md) for the full list of supported integrations.

--- a/engineering/CONNECTORS.md
+++ b/engineering/CONNECTORS.md
@@ -21,7 +21,7 @@ operation safely, or the workflow depends on MCP-only capabilities.
 | Chat | `~~chat` | Slack MCP | Microsoft Teams |
 | Source control | `~~source control` | GitHub via `gh` CLI | GitLab, Bitbucket |
 | Project tracker | `~~project tracker` | Linear MCP, Asana MCP, Atlassian MCP (Jira/Confluence) | Shortcut, ClickUp |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot | Confluence, Guru, Coda |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Confluence, Guru, Coda |
 | Monitoring | `~~monitoring` | Datadog MCP | New Relic, Grafana, Splunk |
 | Incident management | `~~incident management` | PagerDuty MCP | Opsgenie, Incident.io, FireHydrant |
 | CI/CD | `~~CI/CD` | — | CircleCI, GitHub Actions, Jenkins, BuildKite |

--- a/engineering/README.md
+++ b/engineering/README.md
@@ -113,7 +113,7 @@ Connect your tools for a richer experience:
 | **Monitoring** | Datadog, New Relic | Logs, metrics, alerts, dashboards |
 | **Incident management** | PagerDuty, Opsgenie | On-call schedules, incident tracking, paging |
 | **Chat** | Slack, Teams | Team discussions, standup channels |
-| **Knowledge base** | Notion MCP with `ntn` CLI pilot, Confluence | ADRs, runbooks, onboarding docs |
+| **Knowledge base** | Notion MCP with `ntn` CLI pilot for pages/data sources/files, Confluence | ADRs, runbooks, onboarding docs |
 
 See [CONNECTORS.md](CONNECTORS.md) for the full list of supported integrations.
 

--- a/enterprise-search/CONNECTORS.md
+++ b/enterprise-search/CONNECTORS.md
@@ -23,7 +23,7 @@ This plugin uses `~~category` references extensively as source labels in search 
 | Chat | `~~chat` | Slack MCP | Microsoft Teams, Discord |
 | Email | `~~email` | Microsoft 365 MCP | — |
 | Cloud storage | `~~cloud storage` | Microsoft 365 MCP | Dropbox |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot, Guru via `guru` CLI | Confluence, Slite |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files, Guru via `guru` CLI | Confluence, Slite |
 | Project tracker | `~~project tracker` | Atlassian MCP (Jira/Confluence), Asana MCP | Linear, monday.com |
 | CRM | `~~CRM` | *(not pre-configured)* | Salesforce, HubSpot |
 | Office suite | `~~office suite` | Microsoft 365 | Google Workspace via `gws` CLI |

--- a/legal/CONNECTORS.md
+++ b/legal/CONNECTORS.md
@@ -24,6 +24,6 @@ MCP-only capabilities.
 | CRM | `~~CRM` | HubSpot MCP | Salesforce, Pipedrive |
 | Email | `~~email` | Gmail via `gws` CLI | Microsoft 365 |
 | E-signature | `~~e-signature` | DocuSign MCP | Adobe Sign, PandaDoc |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot | Confluence, Guru, Coda |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Confluence, Guru, Coda |
 
 Contract playbooks, fallback positions, approved templates, jurisdiction preferences, and escalation rules are organization-specific. Keep those in gitignored local notes, user/project memory, or a private plugin rather than publishing them in this marketplace repo.

--- a/legal/README.md
+++ b/legal/README.md
@@ -187,7 +187,7 @@ no safe CLI exists:
 | Chat | Slack, Teams | Team requests, notifications, triage |
 | Cloud storage | Google Drive via `gws`, Microsoft 365, Box, Egnyte | Playbooks, templates, precedents |
 | Office suite | Microsoft 365 | Email, calendar, documents |
-| Knowledge base | Notion MCP with `ntn` CLI pilot, Atlassian (Confluence) | Matter tracking, playbooks, policies |
+| Knowledge base | Notion MCP with `ntn` CLI pilot for pages/data sources/files, Atlassian (Confluence) | Matter tracking, playbooks, policies |
 
 See [CONNECTORS.md](CONNECTORS.md) for the full list of supported integrations, including CLM, CRM, e-signature, and additional options.
 

--- a/operations/CONNECTORS.md
+++ b/operations/CONNECTORS.md
@@ -21,8 +21,8 @@ MCP-only capabilities.
 | Calendar | `~~calendar` | Google Calendar via `gws` CLI | Microsoft 365 |
 | Chat | `~~chat` | Slack MCP | Microsoft Teams |
 | Email | `~~email` | Gmail via `gws` CLI, Microsoft 365 MCP | — |
-| ITSM | `~~ITSM` | ServiceNow MCP; pilot `snc` CLI | Zendesk, Freshservice, Jira Service Management |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot, Atlassian MCP (Confluence) | Guru, Coda |
+| ITSM | `~~ITSM` | ServiceNow MCP; pilot official ServiceNow `snc` client for generic record workflows | Zendesk, Freshservice, Jira Service Management |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files, Atlassian MCP (Confluence) | Guru, Coda |
 | Project tracker | `~~project tracker` | Asana MCP, Atlassian MCP (Jira) | Linear, monday.com, ClickUp |
 | Procurement | `~~procurement` | — | Coupa, SAP Ariba, Zip |
 | Office suite | `~~office suite` | Microsoft 365 | Google Workspace via `gws` CLI |

--- a/operations/README.md
+++ b/operations/README.md
@@ -108,9 +108,9 @@ Connect your tools for a richer experience:
 
 | Category | Examples | What It Enables |
 |---|---|---|
-| **ITSM** | ServiceNow MCP with `snc` CLI pilot, Zendesk | Ticket management, change requests, incident tracking |
+| **ITSM** | ServiceNow MCP with official `snc` client pilot, Zendesk | Ticket management, change requests, incident tracking |
 | **Project tracker** | Asana, Jira, monday.com | Project status, resource allocation, task tracking |
-| **Knowledge base** | Notion MCP with `ntn` CLI pilot, Confluence | Process docs, runbooks, policies |
+| **Knowledge base** | Notion MCP with `ntn` CLI pilot for pages/data sources/files, Confluence | Process docs, runbooks, policies |
 | **Chat** | Slack, Teams | Team coordination, approvals, status updates |
 | **Calendar** | Google Calendar, Microsoft 365 | Meeting scheduling, deadline tracking |
 | **Email** | Gmail, Microsoft 365 | Vendor communications, approvals |

--- a/product-management/CONNECTORS.md
+++ b/product-management/CONNECTORS.md
@@ -23,7 +23,7 @@ MCP-only capabilities.
 | Competitive intelligence | `~~competitive intelligence` | Similarweb MCP | Crayon, Klue |
 | Design | `~~design` | Figma MCP | Sketch, Adobe XD |
 | Email | `~~email` | Gmail via `gws` CLI | Microsoft 365 |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot | Confluence, Guru, Coda |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Confluence, Guru, Coda |
 | Meeting transcription | `~~meeting transcription` | Fireflies MCP | Gong, Dovetail, Otter.ai |
 | Product analytics | `~~product analytics` | Amplitude MCP, Pendo MCP | Mixpanel, Heap, FullStory |
 | Project tracker | `~~project tracker` | Linear MCP, Asana MCP, monday.com MCP, ClickUp MCP, Atlassian MCP (Jira/Confluence) | Shortcut, Basecamp |

--- a/product-management/README.md
+++ b/product-management/README.md
@@ -92,7 +92,7 @@ Connect your project management and communication tools for the best experience.
 **Default integrations:**
 - Chat (Slack MCP) for team context and stakeholder threads
 - Project tracker (Linear, Asana, monday.com, ClickUp, Atlassian MCP) for roadmap integration, ticket context, and status tracking
-- Knowledge base (Notion MCP with `ntn` CLI pilot) for existing specs, research, and meeting notes
+- Knowledge base (Notion MCP with `ntn` CLI pilot for pages/data sources/files) for existing specs, research, and meeting notes
 - Design (Figma MCP) for design context and handoff
 - Product analytics (Amplitude MCP, Pendo MCP) for usage data, metrics, and behavioral analysis
 - User feedback (Intercom MCP) for support tickets, feature requests, and user conversations

--- a/productivity/CONNECTORS.md
+++ b/productivity/CONNECTORS.md
@@ -21,6 +21,6 @@ MCP-only capabilities.
 | Chat | `~~chat` | Slack MCP | Microsoft Teams, Discord |
 | Email | `~~email` | Microsoft 365 MCP | — |
 | Calendar | `~~calendar` | Microsoft 365 MCP | — |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot | Confluence, Guru, Coda |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Confluence, Guru, Coda |
 | Project tracker | `~~project tracker` | Asana MCP, Linear MCP, Atlassian MCP (Jira/Confluence), monday.com MCP, ClickUp MCP | Shortcut, Basecamp, Wrike |
 | Office suite | `~~office suite` | Microsoft 365 MCP | — |

--- a/productivity/README.md
+++ b/productivity/README.md
@@ -88,7 +88,7 @@ Connect your communication and project management tools for the best experience.
 **Default integrations:**
 - Chat (Slack MCP) for team context and message scanning
 - Email and calendar (Microsoft 365 MCP) for action item discovery
-- Knowledge base (Notion MCP with `ntn` CLI pilot) for reference documents
+- Knowledge base (Notion MCP with `ntn` CLI pilot for pages/data sources/files) for reference documents
 - Project tracker (Asana, Linear, Atlassian, monday.com, ClickUp MCP) for task syncing
 - Office suite (Microsoft 365 MCP) for documents
 

--- a/sales/CONNECTORS.md
+++ b/sales/CONNECTORS.md
@@ -24,7 +24,7 @@ MCP-only capabilities.
 | CRM | `~~CRM` | HubSpot MCP, Close MCP | Salesforce, Pipedrive, Copper |
 | Data enrichment | `~~data enrichment` | Clay MCP, ZoomInfo MCP, Apollo MCP | Clearbit, Lusha |
 | Email | `~~email` | Gmail via `gws` CLI, Microsoft 365 | — |
-| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot | Confluence, Guru |
+| Knowledge base | `~~knowledge base` | Notion MCP with `ntn` CLI pilot for pages/data sources/files | Confluence, Guru |
 | Meeting transcription | `~~conversation intelligence` | Fireflies MCP | Gong, Chorus, Otter.ai |
 | Project tracker | `~~project tracker` | Atlassian MCP (Jira/Confluence) | Linear, Asana |
 | Sales engagement | `~~sales engagement` | Outreach MCP | Salesloft, Apollo |

--- a/scripts/check_cli_integrations.rb
+++ b/scripts/check_cli_integrations.rb
@@ -26,6 +26,8 @@ INTEGRATIONS = [
     command: "bq",
     owner: "Google Cloud SDK",
     required: true,
+    verify_args: ["version"],
+    verify_output: "BigQuery CLI",
     notes: "Use bq for BigQuery query/list/show/load/extract workflows."
   },
   {
@@ -33,14 +35,20 @@ INTEGRATIONS = [
     command: "hex",
     owner: "Hex CLI",
     required: false,
-    notes: "Pilot hex for Hex projects, apps, cells, runs, users, groups, and connections before removing MCP."
+    verify_args: ["--version"],
+    verify_pattern: "\\Ahex \\d+\\.\\d+\\.\\d+",
+    install_hint: "Install from brew install hex-inc/hex-cli/hex or https://hex.tech/install.sh; the npm package named hex is unrelated.",
+    notes: "Pilot hex for workspace/project/cell/run/connection reads and controlled draft operations; keep MCP for Agent thread create/continue workflows."
   },
   {
     key: "notion",
     command: "ntn",
     owner: "Notion CLI",
     required: false,
-    notes: "Pilot ntn for Notion pages, data sources, Markdown, and API JSON workflows before removing MCP."
+    verify_args: ["--version"],
+    verify_pattern: "\\Antn \\d+\\.\\d+\\.\\d+",
+    install_hint: "Install from https://ntn.dev or npm install --global ntn; use ntn doctor for setup/auth health.",
+    notes: "Pilot ntn for Notion page, data-source, file, and raw API workflows; keep MCP for Notion AI search and database-view workflows."
   },
   {
     key: "guru",
@@ -48,14 +56,19 @@ INTEGRATIONS = [
     owner: "@getguru/cli",
     required: true,
     runners: ["pnpm", "npx"],
+    verify_args: ["--help"],
+    verify_output: "Guru API",
     notes: "Use guru for Guru search and card workflows; prefer one-off pnpm/npx before global install."
   },
   {
     key: "servicenow",
     command: "snc",
-    owner: "ServiceNow CLI",
+    owner: "ServiceNow CLI (snc)",
     required: false,
-    notes: "Pilot snc for generic ServiceNow table/record ITSM workflows before removing MCP."
+    verify_args: ["--help"],
+    verify_outputs: ["ServiceNow", "record"],
+    install_hint: "Install the ServiceNow snc client from ServiceNow Store or github.com/ServiceNow/servicenow-cli; npm snc is unrelated and @servicenow/cli exposes now-cli for app development only.",
+    notes: "Pilot snc for generic ServiceNow record query/get/create/update/delete workflows; keep MCP for instance-specific MCP servers and Now Assist-style workflows."
   },
   {
     key: "context7",
@@ -63,6 +76,8 @@ INTEGRATIONS = [
     owner: "Context7 CLI",
     required: true,
     runners: ["pnpm", "npx"],
+    verify_args: ["--version"],
+    verify_pattern: "\\A\\d+\\.\\d+\\.\\d+",
     notes: "Use ctx7 for library resolution and docs lookup; pnpm dlx or npx is acceptable."
   },
   {
@@ -81,6 +96,8 @@ INTEGRATIONS = [
     owner: "Cloudflare Wrangler",
     required: true,
     runners: ["pnpm", "npx"],
+    verify_args: ["--version"],
+    verify_pattern: "\\A\\d+\\.\\d+\\.\\d+",
     notes: "Use wrangler for Workers, Pages, KV, R2, D1, Queues, and local development."
   }
 ].freeze
@@ -104,11 +121,16 @@ end
 def verify_command(path, integration)
   verify_args = integration[:verify_args]
   verify_output = integration[:verify_output]
-  return { ok: true, output: nil } unless verify_args && verify_output
+  verify_outputs = integration[:verify_outputs]
+  verify_pattern = integration[:verify_pattern]
+  return { ok: true, output: nil } unless verify_args && (verify_output || verify_outputs || verify_pattern)
 
   stdout, stderr, status = Open3.capture3(path, *verify_args)
   output = [stdout, stderr].join("\n")
-  { ok: status.success? && output.include?(verify_output), output: output.strip }
+  expected_strings = Array(verify_outputs || verify_output)
+  strings_ok = expected_strings.empty? || expected_strings.all? { |expected| output.include?(expected) }
+  pattern_ok = verify_pattern.nil? || output.match?(Regexp.new(verify_pattern))
+  { ok: status.success? && strings_ok && pattern_ok, output: output.strip }
 rescue SystemCallError
   { ok: false, output: nil }
 end
@@ -166,6 +188,7 @@ else
     required = result[:required] ? "required" : "optional"
     puts "#{marker.ljust(7)} #{command.ljust(10)} #{required.ljust(8)} #{result[:owner]}"
     puts "        #{install_state}"
+    puts "        install: #{result[:install_hint]}" if result[:install_hint]
     puts "        #{result[:notes]}"
   end
 


### PR DESCRIPTION
## Summary
- verify ambiguous CLI command identities before reporting them as installed
- document Hex, Notion, and ServiceNow pilot boundaries and MCP gaps
- clarify that ServiceNow `snc` means the official Store/GitHub client, not npm `snc` or `@servicenow/cli`

## Validation
- `ruby scripts/validate_repo.rb`
- `ruby scripts/check_cli_integrations.rb --strict`
- `git diff --check`
- tracked email/org/path hygiene scans