### PR TITLE
Add Notion CLI live smoke

### DIFF
--- a/DOMAIN_PACKS_CODEX.md
+++ b/DOMAIN_PACKS_CODEX.md
@@ -97,6 +97,7 @@ Pilot CLI candidates are tracked in [MCP_CLI_REVIEW.md](MCP_CLI_REVIEW.md).
 Do not remove `hex`, `notion`, or `servicenow` MCP configs solely because a CLI
 exists; their CLI paths still need authenticated smoke tests and workflow
 coverage mapping. Hex still needs MCP for Agent thread create/continue,
-Notion still needs MCP for Notion AI search and database-view workflows, and
-ServiceNow still needs MCP for instance-specific MCP servers or server-side
-workflows outside generic record operations.
+Notion still needs MCP for Notion AI search, connected-source search, and
+database-view workflows even though authenticated read-only `ntn` smoke tests
+passed locally, and ServiceNow still needs MCP for instance-specific MCP
+servers or server-side workflows outside generic record operations.

--- a/MCP_CLI_REVIEW.md
+++ b/MCP_CLI_REVIEW.md
@@ -76,6 +76,14 @@ mode `0600` temp file, runs `bq` with
 code, but `bq`/Cloud SDK commands need `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`
 to reliably use the service-account key instead of the active user account.
 
+Notion has a read-only smoke path for the `ntn` pilot. Set
+`NOTION_API_TOKEN_OP_REF=op://<vault>/<item>/<field>` to a 1Password field
+containing the Notion API token. The smoke script verifies `ntn doctor`, API
+endpoint discovery, `v1/users/me`, workspace search, page retrieval when search
+returns a page, and file listing. Passing this smoke test does not make Notion
+a replace-now integration because Notion MCP still covers Notion AI search,
+connected-source search, and database-view workflows.
+
 ## Pilot Findings
 
 ### Hex
@@ -101,6 +109,11 @@ or `npm install --global ntn`; Node.js 22+ and npm 10+ are required for the npm
 path. Use `ntn doctor` for setup/auth health and prefer JSON-capable commands
 such as `ntn api ls --json`, `ntn pages get <page-id> --json`, and
 `ntn datasources query <data-source-id> --filter ... --json`.
+
+Authenticated read-only smoke tests passed locally through `pnpm dlx ntn` using
+a 1Password-sourced `NOTION_API_TOKEN`: `ntn doctor`, `ntn api ls --json`,
+`ntn api v1/users/me`, `ntn api v1/search page_size:=5`, `ntn pages get
+<page-id> --json` from a search result, and `ntn files list --json`.
 
 Keep Notion MCP until authenticated parity is proven for Notion AI search,
 connected-source search, database-view queries, and higher-level agent tools.

--- a/MCP_INVENTORY.md
+++ b/MCP_INVENTORY.md
@@ -44,7 +44,7 @@ omissions, and side-effect expectations.
 | `monday` | HTTP MCP | `https://mcp.monday.com/mcp` | `product-management`, `productivity` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `ms365` | HTTP MCP | `https://microsoft365.mcp.claude.com/mcp` | `enterprise-search`, `finance`, `operations`, `productivity`, `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `namecheap` | local npm MCP | `npx -y @grailautomation/namecheap-mcp` | `namecheap` | `NAMECHEAP_API_KEY`, `NAMECHEAP_API_USER`, `NAMECHEAP_USERNAME` | Public Claude and Codex plugin; npm package exists at `0.1.0`; published `npx` tools/list smoke passed with 8 tools |
-| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Pilot the official `ntn` CLI for page/data-source/file/API workflows; keep MCP until Notion AI search, connected-source search, and database-view coverage are mapped. |
+| `notion` | HTTP MCP | `https://mcp.notion.com/mcp` | `design`, `engineering`, `enterprise-search`, `legal`, `operations`, `product-management`, `productivity`, `sales` |  | Pilot the official `ntn` CLI for page/data-source/file/API workflows; authenticated read-only smoke passed locally. Keep MCP until Notion AI search, connected-source search, and database-view coverage are mapped. |
 | `outreach` | HTTP MCP | `https://mcp.outreach.io/mcp` | `sales` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `pagerduty` | HTTP MCP | `https://mcp.pagerduty.com/mcp` | `engineering` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
 | `pendo` | HTTP MCP | `https://app.pendo.io/mcp/v0/shttp` | `product-management` |  | Reviewed for Codex mapping; see Hosted HTTP MCP Dispositions below |
@@ -90,7 +90,7 @@ previously succeeded.
 | `linear` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `monday` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user OAuth/token setup required. |
 | `ms365` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; Microsoft auth setup required. |
-| `notion` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; pilot the official Notion `ntn` CLI before removing MCP because Notion AI search, connected-source search, and database-view coverage still need mapping. |
+| `notion` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; authenticated read-only `ntn` smoke passed locally, but keep MCP because Notion AI search, connected-source search, and database-view coverage still need mapping. |
 | `outreach` | Included in filtered Codex MCP configs with corrected Codex URL | Original Claude host did not resolve; Codex uses `https://api.outreach.io/mcp/`, which reached an auth challenge. Outreach Amplify/org enablement and user auth required. |
 | `pagerduty` | Included in filtered Codex MCP configs | Hosted HTTP MCP reached auth challenge; user token setup required. |
 | `pendo` | Omitted from Codex filtered configs | The existing URL did not resolve from this network, and Pendo documents regional MCP URLs that must match the user's sign-in hostname; no universal public default is committed. |

--- a/scripts/smoke_cli_integrations.rb
+++ b/scripts/smoke_cli_integrations.rb
@@ -174,6 +174,65 @@ def smoke_guru(timeout)
   warn(key, "help ok; auth status is not configured or failed")
 end
 
+def smoke_notion(timeout)
+  key = "notion"
+  op_ref = ENV["NOTION_API_TOKEN_OP_REF"]
+  return fail_result(key, "set NOTION_API_TOKEN_OP_REF=op://<vault>/<item>/<field>") if op_ref.to_s.empty?
+  return fail_result(key, "1Password CLI `op` is not on PATH") unless executable_path("op")
+
+  prefix = command_prefix("ntn", package: "ntn")
+  return fail_result(key, "ntn is unavailable and neither pnpm nor npx can run it") unless prefix
+
+  token_result = run_command(["op", "read", op_ref], timeout: timeout)
+  return fail_result(key, "could not read Notion token from 1Password: #{failure_detail(token_result)}") unless token_result[:ok]
+
+  token = token_result.fetch(:stdout).strip
+  return fail_result(key, "Notion token is empty") if token.empty?
+
+  env = { "NOTION_API_TOKEN" => token }
+  doctor = run_command([*prefix, "doctor"], env: env, timeout: timeout)
+  return fail_result(key, "ntn doctor failed: #{failure_detail(doctor)}") unless doctor[:ok]
+
+  api_ls = run_command([*prefix, "api", "ls", "--json"], env: env, timeout: timeout)
+  return fail_result(key, "ntn api ls failed: #{failure_detail(api_ls)}") unless api_ls[:ok]
+
+  api_endpoints = JSON.parse(api_ls.fetch(:stdout))
+  return fail_result(key, "ntn api ls did not return an endpoint array") unless api_endpoints.is_a?(Array) && api_endpoints.any?
+
+  users_me = run_command([*prefix, "api", "v1/users/me"], env: env, timeout: timeout)
+  return fail_result(key, "ntn users/me failed: #{failure_detail(users_me)}") unless users_me[:ok]
+
+  user_payload = JSON.parse(users_me.fetch(:stdout))
+  return fail_result(key, "ntn users/me did not return a user object") unless user_payload["object"] == "user"
+
+  search = run_command([*prefix, "api", "v1/search", "page_size:=5"], env: env, timeout: timeout)
+  return fail_result(key, "ntn search failed: #{failure_detail(search)}") unless search[:ok]
+
+  search_payload = JSON.parse(search.fetch(:stdout))
+  results = Array(search_payload["results"])
+  first_page = results.find { |item| item["object"] == "page" && item["id"] }
+  page_status =
+    if first_page
+      page_get = run_command([*prefix, "pages", "get", first_page.fetch("id"), "--json"], env: env, timeout: timeout)
+      return fail_result(key, "ntn pages get failed: #{failure_detail(page_get)}") unless page_get[:ok]
+
+      JSON.parse(page_get.fetch(:stdout))
+      "ok"
+    else
+      "skipped:no-page-result"
+    end
+
+  files = run_command([*prefix, "files", "list", "--json"], env: env, timeout: timeout)
+  return fail_result(key, "ntn files list failed: #{failure_detail(files)}") unless files[:ok]
+
+  file_payload = JSON.parse(files.fetch(:stdout))
+  return fail_result(key, "ntn files list did not return an array") unless file_payload.is_a?(Array)
+
+  pass(key, "doctor/api/search/files ok; search_results=#{results.size}; page_get=#{page_status}; files=#{file_payload.size}")
+rescue JSON::ParserError => e
+  fail_result(key, "ntn did not emit expected JSON: #{e.message}")
+end
+
 def smoke_cf(timeout)
   key = "cloudflare-cf"
   prefix = command_prefix("cf", package: "cf")
@@ -202,6 +261,7 @@ SMOKES = {
   "bigquery" => method(:smoke_bigquery),
   "context7" => method(:smoke_context7),
   "guru" => method(:smoke_guru),
+  "notion" => method(:smoke_notion),
   "cloudflare-cf" => method(:smoke_cf),
   "cloudflare-wrangler" => method(:smoke_wrangler)
 }.freeze


### PR DESCRIPTION
## Summary
- add a Notion `ntn` live smoke target using a 1Password-sourced API token
- record that authenticated read-only Notion CLI smoke passed locally
- keep Notion MCP as the default for Notion AI search, connected-source search, and database-view gaps

## Validation
- `ruby scripts/validate_repo.rb`
- `ruby scripts/check_cli_integrations.rb --strict`
- full `ruby scripts/smoke_cli_integrations.rb --timeout 180` with local BigQuery and Notion 1Password refs
- `ruby -c scripts/smoke_cli_integrations.rb`
- `git diff --check`
- tracked email/org/path hygiene scans

Refs #48.
