### PR TITLE
Add gws smoke and credential inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ Not every plugin uses all component types.
   `GCP_SERVICE_ACCOUNT_OP_REF=op://<vault>/<item>/<field>` and let the script
   use a temporary `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` file; do not commit
   service-account JSON.
+- Use `ruby scripts/inventory_env_credentials.rb` to inspect 1Password `.env`
+  credential availability by item name only. Do not commit generated inventory
+  output or secret values.
 - For plugin-required per-install values, prefer `userConfig` in `plugin.json` and `${user_config.KEY}` substitutions. For optional account/workspace-specific connectors, prefer user/project/local MCP config with environment-variable-backed URLs so broad marketplace plugins do not fail on unset placeholders.
 
 ### Versioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,9 @@ Not every plugin uses all component types.
   `GCP_SERVICE_ACCOUNT_OP_REF=op://<vault>/<item>/<field>` and let the script
   use a temporary `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` file; do not commit
   service-account JSON.
+- Use `ruby scripts/inventory_env_credentials.rb` to inspect 1Password `.env`
+  credential availability by item name only. Do not commit generated inventory
+  output or secret values.
 - For plugin-required per-install values, prefer `userConfig` in `plugin.json` and `${user_config.KEY}` substitutions. For optional account/workspace-specific connectors, prefer user/project/local MCP config with environment-variable-backed URLs so broad marketplace plugins do not fail on unset placeholders.
 
 ### Versioning

--- a/MCP_CLI_REVIEW.md
+++ b/MCP_CLI_REVIEW.md
@@ -67,6 +67,12 @@ separate from the availability checker because it can call SaaS APIs, read local
 auth stores, and invoke one-off `pnpm dlx`/`npx` commands. Run a single check
 with `--only <key>` when validating one integration.
 
+Use `ruby scripts/inventory_env_credentials.rb` to print a credential-name-only
+inventory from the `.env` 1Password vault. It maps known CLI migration
+candidates to present/missing item names without reading or printing secret
+values, which makes the next pilot queue evidence-based without committing local
+vault state.
+
 BigQuery is the current service-account-backed smoke path. Set
 `GCP_SERVICE_ACCOUNT_OP_REF=op://<vault>/<item>/<field>` to a 1Password field
 containing a Google service-account JSON key. The smoke script writes it to a
@@ -75,6 +81,12 @@ mode `0600` temp file, runs `bq` with
 `GOOGLE_APPLICATION_CREDENTIALS` remains appropriate for ADC/client-library
 code, but `bq`/Cloud SDK commands need `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`
 to reliably use the service-account key instead of the active user account.
+
+Google Workspace is covered by the `google-workspace` smoke target. It verifies
+`gws --version`, checks encrypted OAuth state through `gws auth status`, and
+runs a one-item Drive file listing. This is intentionally read-only because
+Gmail, Calendar, Drive, Docs, Sheets, Slides, Pub/Sub, Tasks, and cross-product
+recipes all share the same `gws` auth store.
 
 Notion has a read-only smoke path for the `ntn` pilot. Set
 `NOTION_API_TOKEN_OP_REF=op://<vault>/<item>/<field>` to a 1Password field

--- a/scripts/check_cli_integrations.rb
+++ b/scripts/check_cli_integrations.rb
@@ -61,6 +61,15 @@ INTEGRATIONS = [
     notes: "Use guru for Guru search and card workflows; prefer one-off pnpm/npx before global install."
   },
   {
+    key: "google-workspace",
+    command: "gws",
+    owner: "Google Workspace CLI",
+    required: true,
+    verify_args: ["--version"],
+    verify_pattern: "\\Agws 0\\.(2[2-9]|[3-9]\\d)\\.",
+    notes: "Use gws v0.22.5 or newer for Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Pub/Sub, and Workspace workflows."
+  },
+  {
     key: "servicenow",
     command: "snc",
     owner: "ServiceNow CLI (snc)",

--- a/scripts/inventory_env_credentials.rb
+++ b/scripts/inventory_env_credentials.rb
@@ -1,0 +1,164 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "optparse"
+require "set"
+
+options = {
+  vault: ".env",
+  json: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: ruby scripts/inventory_env_credentials.rb [--vault NAME] [--json]"
+  parser.on("--vault NAME", "1Password vault name to inspect, default: .env") do |value|
+    options[:vault] = value
+  end
+  parser.on("--json", "Emit JSON instead of a text table") do
+    options[:json] = true
+  end
+end.parse!
+
+CANDIDATES = [
+  {
+    key: "bigquery",
+    verdict: "replace-now",
+    refs: ["GCP_SERVICE_ACCOUNT"],
+    status_when_present: "testable"
+  },
+  {
+    key: "cloudflare",
+    verdict: "replace-now",
+    refs: ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN", "CLOUDFLARE_USER_API_TOKEN"],
+    status_when_present: "testable"
+  },
+  {
+    key: "context7",
+    verdict: "replace-now",
+    refs: ["CONTEXT7_API_KEY"],
+    status_when_present: "optional-auth"
+  },
+  {
+    key: "github",
+    verdict: "replace-now",
+    refs: ["GITHUB_PERSONAL_ACCESS_TOKEN"],
+    status_when_present: "testable"
+  },
+  {
+    key: "google-workspace",
+    verdict: "replace-now",
+    refs: [],
+    status_when_present: "uses-local-gws-auth"
+  },
+  {
+    key: "guru",
+    verdict: "replace-now",
+    refs: [],
+    status_when_present: "uses-local-guru-auth"
+  },
+  {
+    key: "hex",
+    verdict: "pilot-blocked",
+    refs: ["HEX_API_TOKEN"],
+    status_when_present: "testable"
+  },
+  {
+    key: "intercom",
+    verdict: "pilot",
+    refs: ["INTERCOM_ACCESS_TOKEN", "INTERCOM_API_TOKEN"],
+    status_when_present: "testable"
+  },
+  {
+    key: "linear",
+    verdict: "pilot",
+    refs: ["LINEAR_API_KEY"],
+    status_when_present: "testable"
+  },
+  {
+    key: "namecheap",
+    verdict: "wrapper-candidate",
+    refs: ["NAMECHEAP_API_KEY", "NAMECHEAP_API_USER", "NAMECHEAP_USERNAME"],
+    status_when_present: "testable"
+  },
+  {
+    key: "notion",
+    verdict: "pilot-keep-mcp",
+    refs: ["NOTION_API_KEY"],
+    status_when_present: "testable"
+  },
+  {
+    key: "servicenow",
+    verdict: "pilot-blocked",
+    refs: ["SERVICENOW_INSTANCE_URL", "SERVICENOW_TOKEN", "SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"],
+    status_when_present: "testable"
+  },
+  {
+    key: "slack",
+    verdict: "wrapper-candidate",
+    refs: ["SLACK_MCP_XOXP_TOKEN"],
+    status_when_present: "mcp-token-present"
+  },
+  {
+    key: "workato",
+    verdict: "public-plugin",
+    refs: ["WORKATO_API_TOKEN"],
+    status_when_present: "testable"
+  }
+].freeze
+
+def op_available?
+  ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |directory|
+    path = File.join(directory, "op")
+    File.file?(path) && File.executable?(path)
+  end
+end
+
+abort "1Password CLI `op` is not on PATH" unless op_available?
+
+stdout, stderr, status = Open3.capture3("op", "item", "list", "--vault", options.fetch(:vault), "--format", "json")
+abort "op item list failed: #{stderr.strip}" unless status.success?
+
+items = JSON.parse(stdout)
+titles = items.map { |item| item.fetch("title") }.to_set
+
+results = CANDIDATES.map do |candidate|
+  refs = candidate.fetch(:refs)
+  present = refs.select { |ref| titles.include?(ref) }
+  missing = refs - present
+  status =
+    if refs.empty?
+      candidate.fetch(:status_when_present)
+    elsif missing.empty?
+      candidate.fetch(:status_when_present)
+    elsif present.any?
+      "partial"
+    else
+      "blocked-missing-credential"
+    end
+
+  {
+    key: candidate.fetch(:key),
+    verdict: candidate.fetch(:verdict),
+    status: status,
+    present_refs: present,
+    missing_refs: missing
+  }
+end
+
+if options[:json]
+  puts JSON.pretty_generate(results)
+else
+  puts "Credential availability inventory for vault #{options.fetch(:vault).inspect}"
+  puts
+  results.each do |result|
+    puts "#{result.fetch(:status).ljust(28)} #{result.fetch(:key).ljust(18)} #{result.fetch(:verdict)}"
+    refs = result.fetch(:present_refs)
+    puts "    present: #{refs.join(", ")}" if refs.any?
+    missing = result.fetch(:missing_refs)
+    puts "    missing: #{missing.join(", ")}" if missing.any?
+  end
+  puts
+  puts "This script prints item names only. It never reads or prints secret values."
+end

--- a/scripts/smoke_cli_integrations.rb
+++ b/scripts/smoke_cli_integrations.rb
@@ -174,6 +174,36 @@ def smoke_guru(timeout)
   warn(key, "help ok; auth status is not configured or failed")
 end
 
+def smoke_google_workspace(timeout)
+  key = "google-workspace"
+  return fail_result(key, "gws is not on PATH") unless executable_path("gws")
+
+  version = run_command(["gws", "--version"], timeout: timeout)
+  return fail_result(key, "gws --version failed: #{failure_detail(version)}") unless version[:ok]
+  return fail_result(key, "gws --version did not report gws 0.22.x or newer") unless version[:stdout].match?(/gws 0\.(2[2-9]|[3-9]\d)\./)
+
+  auth = run_command(["gws", "auth", "status"], timeout: timeout)
+  return fail_result(key, "gws auth status failed: #{failure_detail(auth)}") unless auth[:ok]
+
+  auth_payload = JSON.parse(auth.fetch(:stdout))
+  return fail_result(key, "gws auth method is #{auth_payload["auth_method"].inspect}") unless auth_payload["auth_method"]
+  return fail_result(key, "gws encrypted credentials are missing") unless auth_payload["encrypted_credentials_exists"]
+  return fail_result(key, "gws token is not valid") unless auth_payload["token_valid"]
+
+  list = run_command(
+    ["gws", "drive", "files", "list", "--params", '{"pageSize":1,"fields":"files(id,name,mimeType),nextPageToken"}', "--format", "json"],
+    timeout: timeout
+  )
+  return fail_result(key, "gws drive files list failed: #{failure_detail(list)}") unless list[:ok]
+
+  list_payload = JSON.parse(list.fetch(:stdout))
+  return fail_result(key, "gws drive files list did not return a files array") unless list_payload["files"].is_a?(Array)
+
+  pass(key, "version/auth ok; drive files list ok; files=#{list_payload["files"].size}")
+rescue JSON::ParserError => e
+  fail_result(key, "gws did not emit expected JSON: #{e.message}")
+end
+
 def smoke_notion(timeout)
   key = "notion"
   op_ref = ENV["NOTION_API_TOKEN_OP_REF"]
@@ -261,6 +291,7 @@ SMOKES = {
   "bigquery" => method(:smoke_bigquery),
   "context7" => method(:smoke_context7),
   "guru" => method(:smoke_guru),
+  "google-workspace" => method(:smoke_google_workspace),
   "notion" => method(:smoke_notion),
   "cloudflare-cf" => method(:smoke_cf),
   "cloudflare-wrangler" => method(:smoke_wrangler)


### PR DESCRIPTION
## Summary
- add Google Workspace to CLI availability and live smoke checks
- add a credential-name-only 1Password inventory helper for choosing the next CLI pilot
- mark Hex and ServiceNow blocked externally via issue labels/comments

## Validation
- `ruby scripts/validate_repo.rb`
- `ruby scripts/check_cli_integrations.rb --strict`
- full `ruby scripts/smoke_cli_integrations.rb --timeout 180` with local BigQuery and Notion 1Password refs
- `ruby scripts/inventory_env_credentials.rb --json`
- `ruby -c scripts/smoke_cli_integrations.rb`
- `ruby -c scripts/inventory_env_credentials.rb`
- `git diff --check`
- tracked email/org/path hygiene scans
