### PR TITLE
Expand Linear CLI read smoke

### DIFF
--- a/MCP_CLI_REVIEW.md
+++ b/MCP_CLI_REVIEW.md
@@ -100,10 +100,11 @@ Linear has a read-only plus dry-run smoke path for the `@kyaukyuai/linear-cli`
 pilot. Set `LINEAR_API_KEY_OP_REF=op://<vault>/<item>/<field>` to a 1Password
 field containing a Linear API key. The smoke script runs the CLI from an
 isolated temporary `XDG_CONFIG_HOME`, writes plaintext CLI credentials only to
-that temporary directory, lists teams, issues, projects, and documents as JSON,
-and verifies an issue-create dry-run preview. Passing this smoke test does not
-make Linear a replace-now integration because the hosted Linear MCP is official
-and low-risk write/apply receipts still need validation before removing MCP.
+that temporary directory, lists teams/issues/projects/documents as JSON,
+resolves and views a listed issue, lists that issue's comments, and verifies an
+issue-create dry-run preview. Passing this smoke test does not make Linear a
+replace-now integration because the hosted Linear MCP is official and low-risk
+write/apply receipts still need validation before removing MCP.
 
 ## Pilot Findings
 
@@ -125,12 +126,13 @@ Authenticated read-only and dry-run smoke tests passed locally through
 `pnpm dlx @kyaukyuai/linear-cli` using a 1Password-sourced `LINEAR_API_KEY`.
 The smoke used an isolated temporary `XDG_CONFIG_HOME`, `linear auth login
 --key ... --plaintext`, `linear team list --json`, `linear issue list --json`,
-`linear project list --json`, `linear document list --json`, and `linear issue
-create --dry-run --json`.
+`linear resolve issue --json`, `linear issue view --json`, `linear issue
+comment list --json`, `linear project list --json`, `linear document list
+--json`, and `linear issue create --dry-run --json`.
 
 Keep Linear MCP until at least one low-risk apply path is validated with a
-receipt, comment/list workflows are exercised against real issues, and domain
-pack guidance is updated for both Claude and Codex in the same direction.
+receipt and domain pack guidance is updated for both Claude and Codex in the
+same direction.
 
 ### Microsoft 365
 

--- a/scripts/smoke_cli_integrations.rb
+++ b/scripts/smoke_cli_integrations.rb
@@ -333,6 +333,36 @@ def smoke_linear(timeout)
     return issue_payload if issue_payload.is_a?(Result)
     return fail_result(key, "linear issue list did not return an array") unless issue_payload.is_a?(Array)
 
+    issue_detail_status = "skipped:no-issues"
+    if (issue = issue_payload.find { |item| item["identifier"] })
+      issue_ref = issue.fetch("identifier")
+
+      resolve = run_command([*prefix, "resolve", "issue", issue_ref, "--json"], env: env, timeout: timeout)
+      return fail_result(key, "linear resolve issue failed: #{failure_detail(resolve)}") unless resolve[:ok]
+
+      resolve_payload = parse_json_output(key, resolve, "linear resolve issue")
+      return resolve_payload if resolve_payload.is_a?(Result)
+      unless resolve_payload["status"] == "resolved" && resolve_payload.dig("resolved", "identifier") == issue_ref
+        return fail_result(key, "linear resolve issue did not resolve #{issue_ref}")
+      end
+
+      view = run_command([*prefix, "issue", "view", issue_ref, "--json", "--no-download"], env: env, timeout: timeout)
+      return fail_result(key, "linear issue view failed: #{failure_detail(view)}") unless view[:ok]
+
+      view_payload = parse_json_output(key, view, "linear issue view")
+      return view_payload if view_payload.is_a?(Result)
+      return fail_result(key, "linear issue view returned #{view_payload["identifier"].inspect}, expected #{issue_ref}") unless view_payload["identifier"] == issue_ref
+
+      comments = run_command([*prefix, "issue", "comment", "list", issue_ref, "--json"], env: env, timeout: timeout)
+      return fail_result(key, "linear issue comment list failed: #{failure_detail(comments)}") unless comments[:ok]
+
+      comment_payload = parse_json_output(key, comments, "linear issue comment list")
+      return comment_payload if comment_payload.is_a?(Result)
+      return fail_result(key, "linear issue comment list did not return an array") unless comment_payload.is_a?(Array)
+
+      issue_detail_status = "ok"
+    end
+
     projects = run_command([*prefix, "project", "list", "--json"], env: env, timeout: timeout)
     return fail_result(key, "linear project list failed: #{failure_detail(projects)}") unless projects[:ok]
 
@@ -373,7 +403,7 @@ def smoke_linear(timeout)
     end
 
     command_count = capabilities_payload.dig("automationTier", "allCommands").size
-    pass(key, "auth/read/dry-run ok; team=#{team_key}; issues=#{issue_payload.size}; projects=#{project_payload.size}; documents=#{document_payload.size}; commands=#{command_count}")
+    pass(key, "auth/read/dry-run ok; team=#{team_key}; issues=#{issue_payload.size}; issue_detail=#{issue_detail_status}; projects=#{project_payload.size}; documents=#{document_payload.size}; commands=#{command_count}")
   end
 end
 


### PR DESCRIPTION
## Summary
- extend the Linear CLI smoke to resolve and view a listed issue
- add read-only issue comment-list coverage before the dry-run write preview
- update the Linear pilot ledger so the remaining blocker is specifically low-risk apply receipts

## Validation
- ruby -c scripts/smoke_cli_integrations.rb
- LINEAR_API_KEY_OP_REF='op://.env/LINEAR_API_KEY/credential' ruby scripts/smoke_cli_integrations.rb --only linear --timeout 180
- ruby scripts/validate_repo.rb
- git diff --check