### PR TITLE
Expose karabiner-elements to Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -89,6 +89,18 @@
       "category": "Productivity"
     },
     {
+      "name": "karabiner-elements",
+      "source": {
+        "source": "local",
+        "path": "./karabiner-elements"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
       "name": "salesforce-soql",
       "source": {
         "source": "local",

--- a/CODEX_MIGRATION.md
+++ b/CODEX_MIGRATION.md
@@ -19,7 +19,7 @@ Current Codex docs baseline:
 
 The Codex installability pass is complete for the reviewed plugin set. The
 tracked repo-local Codex marketplace at `.agents/plugins/marketplace.json`
-contains 32 plugins, and each listed plugin has a matching
+contains 33 plugins, and each listed plugin has a matching
 `.codex-plugin/plugin.json`.
 
 This means the plugins are visible and available for install in Codex. Live
@@ -28,12 +28,11 @@ are quality/runtime follow-ups, not blockers for Codex marketplace visibility.
 Handle those only when a plugin is actively being installed, used, or promoted
 from MCP to a CLI-backed default.
 
-Three Claude marketplace plugins are intentionally not listed for Codex:
+Two Claude marketplace plugins are intentionally not listed for Codex:
 
 | Plugin | Why it is not listed |
 | --- | --- |
 | `jq-for-clawd` | Claude Code session-history skill; Codex uses different session paths and JSONL shapes, so the Codex-compatible split is `codex-session-history`. |
-| `karabiner-elements` | Local macOS keyboard-remapping config workflow; useful for Claude, but Codex listing would imply editing personal machine config without a Codex side-effect policy. |
 | `playwright-cli` | Already covered by the user-level Codex `playwright` skill, which has Codex-specific wrapper scripts and policy. Listing this repo copy would mostly create duplicate choices. |
 
 The previous `agents` plugin was removed from the Claude marketplace and repo
@@ -53,6 +52,7 @@ The tracked Codex marketplace exposes:
 | `python-quickbooks` | Migrated | Skill-only library reference; examples use placeholders rather than live credentials. |
 | `terminal-tidbits` | Migrated | User-data path moved outside the plugin directory; defaults remain plugin-bundled. |
 | `espanso` | Migrated | Local text-expander config skill. Codex exposure is user-invoked only and keeps preview, backup, confirmation, and verification rules for live machine-state edits. |
+| `karabiner-elements` | Migrated | Local keyboard-remapping config skill. Codex exposure is user-invoked only and keeps inspect, preview, backup, confirmation, lint, apply, verify, and rollback rules for live machine-state edits. |
 | `salesforce-soql` | Migrated | Salesforce CLI/reference workflow; no bundled MCP and org schemas remain local/ignored. |
 | `oasb-scaffold` | Migrated | Repo-specific OASBuilder convention skill; exposed for personal/repo-local usefulness. |
 | `workato-api` | Migrated | REST reference and curl/httpx execution patterns; credentials come from environment variables or gitignored local notes. |
@@ -137,7 +137,7 @@ These are working classifications, not final deletion decisions:
 | `google-workspace` | `public-marketplace` | Keep as one broad plugin for Claude and Codex. The integration is CLI-backed rather than MCP-backed; require current `gws` auth and side-effect confirmation instead of splitting by product or action class. |
 | `jq-for-clawd` / `codex-session-history` | `public-marketplace` split | Keep `jq-for-clawd` as the Claude Code session-history skill; expose `codex-session-history` separately for Codex's distinct session JSONL structure. |
 | `espanso` | `public-marketplace` | Keep listed for Claude and Codex. Treat text-expander config as live user machine state: inspect, preview, back up, confirm, apply, and verify. |
-| `karabiner-elements` | `public-marketplace` Claude-only | Keep in the public Claude marketplace as a generic macOS config workflow; do not expose to Codex until ordinary remaps and profile/service changes have mandatory preview/confirmation wording or tooling. |
+| `karabiner-elements` | `public-marketplace` | Keep listed for Claude and Codex. Treat keyboard-remapping config as live user machine state: inspect, preview, back up, confirm, lint when possible, apply, verify, and document rollback. |
 | `dev-browser` | `public-marketplace` | Keep listed for Claude and Codex. Standalone browser mode is the default; extension mode intentionally uses logged-in Chrome state when requested. |
 | `playwright-cli` | `public-marketplace` Claude-only | Keep listed for Claude. Codex should keep using the user-level `playwright` skill unless a concrete gap appears; that skill has Codex-specific wrapper scripts and headless defaults. |
 

--- a/karabiner-elements/.codex-plugin/plugin.json
+++ b/karabiner-elements/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "karabiner-elements",
+  "description": "Manage Karabiner-Elements keyboard remaps, complex modifications, profiles, and macOS keyboard automation config.",
+  "author": {
+    "name": "Grail Automation",
+    "url": "https://grailautomation.com/"
+  },
+  "repository": "https://github.com/grailautomation/claude-plugins/tree/main/karabiner-elements",
+  "keywords": [
+    "karabiner",
+    "keyboard",
+    "macos",
+    "remapping",
+    "shortcuts",
+    "automation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Karabiner Elements",
+    "shortDescription": "Manage Karabiner keyboard remaps safely",
+    "longDescription": "Use Karabiner Elements to inspect and update local keyboard remapping configuration. The skill treats Karabiner config as live machine state: inspect active profiles/devices first, show the intended JSON change or diff, back up edited files, require confirmation before writes or profile/service changes, lint when possible, and document rollback.",
+    "developerName": "Grail Automation",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use karabiner-elements to add this keyboard remap",
+      "Review my Karabiner config for conflicts",
+      "Help create a Karabiner complex modification"
+    ],
+    "brandColor": "#7C3AED",
+    "screenshots": []
+  }
+}

--- a/karabiner-elements/skills/karabiner-elements/SKILL.md
+++ b/karabiner-elements/skills/karabiner-elements/SKILL.md
@@ -19,7 +19,9 @@ Configure, customize, and troubleshoot Karabiner-Elements on macOS — including
 
 - Treat Karabiner configuration as user machine state. Read the current config before editing it.
 - Resolve paths from environment variables when set; otherwise use Karabiner's macOS defaults.
+- Show the exact JSON change or diff before editing live config.
 - Back up `karabiner.json` before any write.
+- Ask for confirmation before any write, profile selection, variable change, service restart, or other live behavior change.
 - Prefer adding focused complex modification files over rewriting unrelated profile data.
 - Lint complex modifications with `karabiner_cli` when the CLI is available.
 - Do not run uninstall, root-owned environment-file edits, or other destructive maintenance commands unless the user explicitly asks for that action.
@@ -62,10 +64,10 @@ The main `karabiner.json` structure:
 # Profile management
 "$CLI_PATH" --list-profile-names
 "$CLI_PATH" --show-current-profile-name
-"$CLI_PATH" --select-profile 'Profile Name'
+"$CLI_PATH" --select-profile 'Profile Name'  # confirm before running
 
 # Variable management
-"$CLI_PATH" --set-variables '{"my_var":1, "another_var":true}'
+"$CLI_PATH" --set-variables '{"my_var":1, "another_var":true}'  # confirm before running
 
 # Configuration validation
 "$CLI_PATH" --lint-complex-modifications "$COMPLEX_MODS_DIR"/*.json
@@ -132,9 +134,10 @@ When a user requests a new mapping:
 2. **Check current config** — Read existing karabiner.json
 3. **Validate** — Ensure no conflicts with existing rules
 4. **Generate JSON** — Create the proper rule structure
-5. **Apply changes** — Add to complex_modifications in karabiner.json or create a separate file in assets/complex_modifications/
-6. **Test** — Verify the change took effect
-7. **Document** — Explain what was changed
+5. **Preview changes** — Show the generated JSON or diff and ask for confirmation
+6. **Apply changes** — Add to complex_modifications in karabiner.json or create a separate file in assets/complex_modifications/
+7. **Test** — Verify the change took effect
+8. **Document** — Explain what was changed and how to roll back
 
 Always back up before modifying:
 ```bash
@@ -142,6 +145,8 @@ cp ~/.config/karabiner/karabiner.json ~/.config/karabiner/karabiner.json.backup.
 ```
 
 Use the configuration manager at [scripts/config_manager.py](scripts/config_manager.py) for safe JSON manipulation.
+Its write commands preview by default; pass `--yes` only after the user approves
+the shown diff.
 
 ## Important Notes
 

--- a/karabiner-elements/skills/karabiner-elements/agents/openai.yaml
+++ b/karabiner-elements/skills/karabiner-elements/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/karabiner-elements/skills/karabiner-elements/scripts/config_manager.py
+++ b/karabiner-elements/skills/karabiner-elements/scripts/config_manager.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 import shutil
+import difflib
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, Dict, Any, List
@@ -22,7 +23,13 @@ COMPLEX_MODS_DIR = env_path(
     'KARABINER_COMPLEX_MODS_DIR',
     Path.home() / '.config/karabiner/assets/complex_modifications',
 )
-BACKUP_DIR = env_path('KARABINER_BACKUP_DIR', Path.home() / '.config/karabiner/backups')
+
+if 'KARABINER_BACKUP_DIR' in os.environ:
+    BACKUP_DIR = env_path('KARABINER_BACKUP_DIR', Path.home() / '.config/karabiner/backups')
+elif 'KARABINER_CONFIG_FILE' in os.environ:
+    BACKUP_DIR = CONFIG_PATH.parent / 'backups'
+else:
+    BACKUP_DIR = Path.home() / '.config/karabiner/backups'
 
 def backup_config() -> Path:
     """Create a timestamped backup of the current config."""
@@ -38,11 +45,30 @@ def load_config() -> Dict[str, Any]:
         raise FileNotFoundError(f"Config not found: {CONFIG_PATH}")
     return json.loads(CONFIG_PATH.read_text())
 
-def save_config(config: Dict[str, Any], backup: bool = True) -> None:
+def serialized_config(config: Dict[str, Any]) -> str:
+    """Serialize a config in the same format this helper writes."""
+    return json.dumps(config, indent=4)
+
+def diff_config(original: str, config: Dict[str, Any]) -> str:
+    """Return a unified diff between original config text and updated config."""
+    updated = serialized_config(config)
+    return "\n".join(
+        difflib.unified_diff(
+            original.splitlines(),
+            updated.splitlines(),
+            fromfile=str(CONFIG_PATH),
+            tofile=f"{CONFIG_PATH} (proposed)",
+            lineterm="",
+        )
+    )
+
+def save_config(config: Dict[str, Any], backup: bool = True) -> Optional[Path]:
     """Save configuration with optional backup."""
+    backup_path = None
     if backup:
-        backup_config()
-    CONFIG_PATH.write_text(json.dumps(config, indent=4))
+        backup_path = backup_config()
+    CONFIG_PATH.write_text(serialized_config(config))
+    return backup_path
 
 def get_selected_profile(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Get the currently selected profile."""
@@ -164,10 +190,13 @@ if __name__ == '__main__':
     simple_parser = subparsers.add_parser('add-simple', help='Add simple modification')
     simple_parser.add_argument('from_key', help='Source key code')
     simple_parser.add_argument('to_key', help='Target key code')
+    simple_parser.add_argument('--dry-run', action='store_true', help='Preview the diff without writing')
+    simple_parser.add_argument('--yes', action='store_true', help='Apply the change after preview/approval')
     
     args = parser.parse_args()
     
     try:
+        original_text = CONFIG_PATH.read_text() if CONFIG_PATH.exists() else None
         config = load_config()
         
         if args.command == 'list-profiles':
@@ -191,10 +220,25 @@ if __name__ == '__main__':
         
         elif args.command == 'add-simple':
             profile = get_selected_profile(config)
-            if profile:
-                add_simple_modification(profile, args.from_key, args.to_key)
-                save_config(config)
-                print(f"Added: {args.from_key} → {args.to_key}")
+            if not profile:
+                print("No selected profile", file=sys.stderr)
+                sys.exit(1)
+
+            add_simple_modification(profile, args.from_key, args.to_key)
+            diff = diff_config(original_text or "", config)
+            if diff:
+                print(diff)
+            else:
+                print("No changes")
+                sys.exit(0)
+
+            if args.dry_run or not args.yes:
+                print("\nDry run only. Re-run with --yes after user approval to apply this change.")
+                sys.exit(0)
+
+            backup_path = save_config(config)
+            print(f"Backup created: {backup_path}")
+            print(f"Added: {args.from_key} -> {args.to_key}")
         
         else:
             parser.print_help()


### PR DESCRIPTION
## Summary
- add Codex manifest and marketplace entry for `karabiner-elements`
- keep Karabiner user-invoked for Codex and document inspect/preview/confirm/backup/verify/rollback rules
- make `config_manager.py add-simple` preview by default, require `--yes` for writes, and keep scratch-config backups beside overridden config files
- update the Codex migration ledger to 33 listed plugins

## Validation
- strict scratch-config smoke test for `config_manager.py add-simple --dry-run` and `--yes`
- `python3 -m py_compile karabiner-elements/skills/karabiner-elements/scripts/config_manager.py`
- `ruby scripts/validate_repo.rb`
- marketplace parity check: 33 entries, no missing manifests, no unlisted manifests
- `git diff --check`
- public-hygiene grep checks from `AGENTS.md`
